### PR TITLE
Add quarkus-jsonp dependency to quarkus-test-artemis

### DIFF
--- a/test-framework/pom.xml
+++ b/test-framework/pom.xml
@@ -18,6 +18,10 @@
             <artifactId>quarkus-test-common</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jsonp</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.activemq</groupId>
             <artifactId>artemis-server</artifactId>
         </dependency>


### PR DESCRIPTION
This dependency is gone from quarkus-test-common and is apparently required:
```
2022-03-29T05:47:57.3752129Z Caused by: java.util.concurrent.CompletionException: java.lang.NoClassDefFoundError: javax/json/JsonValue
2022-03-29T05:47:57.3752647Z 	at java.base/java.util.concurrent.CompletableFuture.encodeThrowable(CompletableFuture.java:314)
2022-03-29T05:47:57.3753166Z 	at java.base/java.util.concurrent.CompletableFuture.completeThrowable(CompletableFuture.java:319)
2022-03-29T05:47:57.3753658Z 	at java.base/java.util.concurrent.CompletableFuture$AsyncRun.run(CompletableFuture.java:1739)
2022-03-29T05:47:57.3754144Z 	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
2022-03-29T05:47:57.3754632Z 	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
2022-03-29T05:47:57.3755016Z 	at java.base/java.lang.Thread.run(Thread.java:829)
2022-03-29T05:47:57.3755345Z Caused by: java.lang.NoClassDefFoundError: javax/json/JsonValue
2022-03-29T05:47:57.3756030Z 	at org.apache.activemq.artemis.uri.schema.connector.TCPTransportConfigurationSchema.getTransportConfigurations(TCPTransportConfigurationSchema.java:68)
2022-03-29T05:47:57.3756973Z 	at org.apache.activemq.artemis.uri.schema.connector.TCPTransportConfigurationSchema.internalNewObject(TCPTransportConfigurationSchema.java:49)
2022-03-29T05:47:57.3757848Z 	at org.apache.activemq.artemis.uri.schema.connector.TCPTransportConfigurationSchema.internalNewObject(TCPTransportConfigurationSchema.java:32)
2022-03-29T05:47:57.3758535Z 	at org.apache.activemq.artemis.utils.uri.URISchema.newObject(URISchema.java:86)
2022-03-29T05:47:57.3759061Z 	at org.apache.activemq.artemis.utils.uri.URISchema.newObject(URISchema.java:30)
2022-03-29T05:47:57.3759546Z 	at org.apache.activemq.artemis.utils.uri.URIFactory.newObject(URIFactory.java:59)
2022-03-29T05:47:57.3760112Z 	at org.apache.activemq.artemis.core.config.ConfigurationUtils.parseAcceptorURI(ConfigurationUtils.java:158)
2022-03-29T05:47:57.3776856Z 	at org.apache.activemq.artemis.core.deployers.impl.FileConfigurationParser.parseAcceptorTransportConfiguration(FileConfigurationParser.java:1545)
2022-03-29T05:47:57.3777748Z 	at org.apache.activemq.artemis.core.deployers.impl.FileConfigurationParser.parseMainConfig(FileConfigurationParser.java:549)
2022-03-29T05:47:57.3778412Z 	at org.apache.activemq.artemis.core.config.impl.FileConfiguration.parse(FileConfiguration.java:56)
2022-03-29T05:47:57.3779042Z 	at org.apache.activemq.artemis.core.config.FileDeploymentManager.readConfiguration(FileDeploymentManager.java:81)
2022-03-29T05:47:57.3779712Z 	at org.apache.activemq.artemis.core.server.embedded.EmbeddedActiveMQ.initStart(EmbeddedActiveMQ.java:128)
2022-03-29T05:47:57.3780330Z 	at org.apache.activemq.artemis.core.server.embedded.EmbeddedActiveMQ.start(EmbeddedActiveMQ.java:115)
2022-03-29T05:47:57.3780866Z 	at io.quarkus.artemis.test.ArtemisTestResource.start(ArtemisTestResource.java:21)
2022-03-29T05:47:57.3781360Z 	at io.quarkus.test.common.TestResourceManager$TestResourceEntryRunnable.run(TestResourceManager.java:452)
2022-03-29T05:47:57.3781859Z 	at java.base/java.util.concurrent.CompletableFuture$AsyncRun.run(CompletableFuture.java:1736)
2022-03-29T05:47:57.3782180Z 	... 3 more
2022-03-29T05:47:57.3782470Z Caused by: java.lang.ClassNotFoundException: javax.json.JsonValue
2022-03-29T05:47:57.3782919Z 	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:581)
2022-03-29T05:47:57.3783396Z 	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:178)
2022-03-29T05:47:57.3783816Z 	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:522)
2022-03-29T05:47:57.3784285Z 	at io.quarkus.bootstrap.classloading.QuarkusClassLoader.loadClass(QuarkusClassLoader.java:464)
2022-03-29T05:47:57.3784829Z 	at io.quarkus.bootstrap.classloading.QuarkusClassLoader.loadClass(QuarkusClassLoader.java:414)
2022-03-29T05:47:57.3785175Z 	... 19 more
```