### PR TITLE
Remove transaction manager in wrapper

### DIFF
--- a/jms/deployment/src/main/java/io/quarkus/artemis/jms/deployment/ArtemisJmsProcessor.java
+++ b/jms/deployment/src/main/java/io/quarkus/artemis/jms/deployment/ArtemisJmsProcessor.java
@@ -12,8 +12,6 @@ import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
 import io.quarkus.artemis.core.deployment.ArtemisBuildTimeConfig;
 import io.quarkus.artemis.core.deployment.ArtemisJmsBuildItem;
 import io.quarkus.artemis.jms.runtime.ArtemisJmsRecorder;
-import io.quarkus.deployment.Capabilities;
-import io.quarkus.deployment.Capability;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
@@ -46,7 +44,6 @@ public class ArtemisJmsProcessor {
     @BuildStep
     ArtemisJmsConfiguredBuildItem configure(ArtemisJmsRecorder recorder, ArtemisBuildTimeConfig config,
             Optional<ArtemisJmsWrapperBuildItem> wrapper,
-            Capabilities capabilities,
             BuildProducer<SyntheticBeanBuildItem> syntheticBeanProducer) {
 
         SyntheticBeanBuildItem.ExtendedBeanConfigurator configurator;
@@ -65,9 +62,7 @@ public class ArtemisJmsProcessor {
         }
 
         configurator.supplier(recorder.getConnectionFactorySupplier(
-                wrapper.orElseGet(() -> new ArtemisJmsWrapperBuildItem(recorder.getDefaultWrapper()))
-                        .getWrapper(),
-                capabilities.isPresent(Capability.TRANSACTIONS)))
+                wrapper.orElseGet(() -> new ArtemisJmsWrapperBuildItem(recorder.getDefaultWrapper())).getWrapper()))
                 .scope(ApplicationScoped.class)
                 .defaultBean()
                 .unremovable()

--- a/jms/runtime/src/main/java/io/quarkus/artemis/jms/runtime/ArtemisJmsRecorder.java
+++ b/jms/runtime/src/main/java/io/quarkus/artemis/jms/runtime/ArtemisJmsRecorder.java
@@ -3,11 +3,9 @@ package io.quarkus.artemis.jms.runtime;
 import java.util.function.Supplier;
 
 import javax.jms.ConnectionFactory;
-import javax.transaction.TransactionManager;
 
 import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
 
-import io.quarkus.arc.Arc;
 import io.quarkus.artemis.core.runtime.ArtemisRuntimeConfig;
 import io.quarkus.runtime.annotations.Recorder;
 
@@ -23,21 +21,20 @@ public class ArtemisJmsRecorder {
     public ArtemisJmsWrapper getDefaultWrapper() {
         return new ArtemisJmsWrapper() {
             @Override
-            public ConnectionFactory wrapConnectionFactory(ActiveMQConnectionFactory cf, TransactionManager tm) {
+            public ConnectionFactory wrapConnectionFactory(ActiveMQConnectionFactory cf) {
                 return cf;
             }
         };
     }
 
-    public Supplier<ConnectionFactory> getConnectionFactorySupplier(ArtemisJmsWrapper wrapper, boolean transaction) {
+    public Supplier<ConnectionFactory> getConnectionFactorySupplier(ArtemisJmsWrapper wrapper) {
         return new Supplier<ConnectionFactory>() {
             @Override
             public ConnectionFactory get() {
                 ActiveMQConnectionFactory connectionFactory = new ActiveMQConnectionFactory(config.url,
                         config.username.orElse(null),
                         config.password.orElse(null));
-                return wrapper.wrapConnectionFactory(connectionFactory,
-                        transaction ? Arc.container().instance(TransactionManager.class).get() : null);
+                return wrapper.wrapConnectionFactory(connectionFactory);
             }
         };
     }

--- a/jms/runtime/src/main/java/io/quarkus/artemis/jms/runtime/ArtemisJmsWrapper.java
+++ b/jms/runtime/src/main/java/io/quarkus/artemis/jms/runtime/ArtemisJmsWrapper.java
@@ -1,10 +1,9 @@
 package io.quarkus.artemis.jms.runtime;
 
 import javax.jms.ConnectionFactory;
-import javax.transaction.TransactionManager;
 
 import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
 
 public interface ArtemisJmsWrapper {
-    ConnectionFactory wrapConnectionFactory(ActiveMQConnectionFactory cf, TransactionManager tm);
+    ConnectionFactory wrapConnectionFactory(ActiveMQConnectionFactory cf);
 }


### PR DESCRIPTION
We don't need to have `transactionManager` in wrapper since it should be obtained by the other extensions such as `messaginghub-pooled-jms` if it decides to add transaction manager integration.