### PR TITLE
#112: Use @Default to get default ServerLocator/ConnectionFactory in healtch cheks

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/artemis/core/runtime/health/ServerLocatorHealthCheck.java
+++ b/core/runtime/src/main/java/io/quarkus/artemis/core/runtime/health/ServerLocatorHealthCheck.java
@@ -1,8 +1,10 @@
 package io.quarkus.artemis.core.runtime.health;
 
+import java.lang.annotation.Annotation;
 import java.util.*;
 
 import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Default;
 
 import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
 import org.apache.activemq.artemis.api.core.client.ServerLocator;
@@ -35,7 +37,13 @@ public class ServerLocatorHealthCheck implements HealthCheck {
     private void processKnownBeans(ArtemisRuntimeConfigs runtimeConfigs, HashSet<String> includedNames) {
         for (String name : includedNames) {
             if (runtimeConfigs.getAllConfigs().get(name) != null) {
-                ServerLocator locator = Arc.container().instance(ServerLocator.class, Identifier.Literal.of(name)).get();
+                Annotation identifier;
+                if (ArtemisUtil.isDefault(name)) {
+                    identifier = Default.Literal.INSTANCE;
+                } else {
+                    identifier = Identifier.Literal.of(name);
+                }
+                ServerLocator locator = Arc.container().instance(ServerLocator.class, identifier).get();
                 if (locator != null) {
                     serverLocators.put(name, locator);
                 }

--- a/jms/runtime/src/main/java/io/quarkus/artemis/jms/runtime/health/ConnectionFactoryHealthCheck.java
+++ b/jms/runtime/src/main/java/io/quarkus/artemis/jms/runtime/health/ConnectionFactoryHealthCheck.java
@@ -1,10 +1,12 @@
 package io.quarkus.artemis.jms.runtime.health;
 
+import java.lang.annotation.Annotation;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 
 import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Default;
 import javax.jms.Connection;
 import javax.jms.ConnectionFactory;
 
@@ -38,8 +40,13 @@ public class ConnectionFactoryHealthCheck implements HealthCheck {
     private void processKnownBeans(ArtemisRuntimeConfigs runtimeConfigs, HashSet<String> includedNames) {
         for (String name : includedNames) {
             if (runtimeConfigs.getAllConfigs().get(name) != null) {
-                ConnectionFactory connectionFactory = Arc.container()
-                        .instance(ConnectionFactory.class, Identifier.Literal.of(name)).get();
+                Annotation identifier;
+                if (ArtemisUtil.isDefault(name)) {
+                    identifier = Default.Literal.INSTANCE;
+                } else {
+                    identifier = Identifier.Literal.of(name);
+                }
+                ConnectionFactory connectionFactory = Arc.container().instance(ConnectionFactory.class, identifier).get();
                 if (connectionFactory != null) {
                     connectionFactories.put(name, connectionFactory);
                 }


### PR DESCRIPTION
In the health checks, get the default ServerLocator/ConnectionFactory through the @Default annotation instead of through the @Identifier annotation.

Resolves #112 .