### PR TITLE
Fix all asciidoc warnings by using pass macro

### DIFF
--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -253,8 +253,8 @@ a|
 a|
 configuration property bound to environment variable
 a|
-* `quarkus.artemis."named".url=${ARTEMIS_NAMED_URL}`
-* `quarkus.artemis.password=${ARTEMIS_PASSWORD}`
+* `quarkus.artemis."named".url=pass:[${ARTEMIS_NAMED_URL}]`
+* `quarkus.artemis.password=pass:[${ARTEMIS_PASSWORD}]`
 a|
 ❌
 a|


### PR DESCRIPTION
Asciidoc interprets strings like ${ARTEMIS_NAMED_URL} as attributes and then issues a WARN during the build that it will skip reference to a missing attribute. This PR uses inline pass macro to tell asciidoc that enclosed content should be excluded from all substitutions.

Proof of all warnings gone:
<img width="1382" alt="image" src="https://github.com/quarkiverse/quarkus-artemis/assets/11942401/68f80c48-8cad-4060-8958-3190c2a8850b">

Proof of warnings before this PR:
<img width="1386" alt="image" src="https://github.com/quarkiverse/quarkus-artemis/assets/11942401/2a65ca6c-24d6-476f-a0b4-4a76acccde53">
