### PR TITLE
Use `graal-sdk` instead of `svm`

### DIFF
--- a/core/runtime/pom.xml
+++ b/core/runtime/pom.xml
@@ -71,8 +71,8 @@
         </dependency>
 
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
-            <artifactId>svm</artifactId>
+            <groupId>org.graalvm.sdk</groupId>
+            <artifactId>graal-sdk</artifactId>
             <scope>provided</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
- Caused by https://github.com/quarkusio/quarkus/pull/34145