### PR TITLE
Cleanup integration tests

### DIFF
--- a/integration-tests/camel-jms/common/src/test/java/io/quarkus/it/artemis/camel/jms/common/BaseSendAndReceiveTest.java
+++ b/integration-tests/camel-jms/common/src/test/java/io/quarkus/it/artemis/camel/jms/common/BaseSendAndReceiveTest.java
@@ -12,8 +12,11 @@ public interface BaseSendAndReceiveTest {
     @Test
     default void test() {
         String body = "body";
-        RestAssured.given().body(body)
+        // @formatter:off
+        RestAssured
+                .given().body(body)
                 .when().post()
                 .then().statusCode(is(Response.Status.OK.getStatusCode())).body(is(body));
+        // @formatter:on
     }
 }

--- a/integration-tests/common/src/test/java/io/quarkus/it/artemis/common/ArtemisHealthCheckHelper.java
+++ b/integration-tests/common/src/test/java/io/quarkus/it/artemis/common/ArtemisHealthCheckHelper.java
@@ -1,5 +1,7 @@
 package io.quarkus.it.artemis.common;
 
+import static org.hamcrest.Matchers.is;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -22,12 +24,16 @@ public class ArtemisHealthCheckHelper {
     }
 
     private static void test(String endpoint, Set<String> expectedConfigurations, String healthCheckMessage) {
-        Response response = RestAssured.with().get(endpoint);
-        Assertions.assertEquals(jakarta.ws.rs.core.Response.Status.OK.getStatusCode(), response.statusCode());
-
+        // @formatter:off
+        Response response = RestAssured
+                .when().get(endpoint)
+                .then()
+                    .statusCode(jakarta.ws.rs.core.Response.Status.OK.getStatusCode())
+                    .body("status", is("UP"))
+                    .extract().response();
+        // @formatter:on
         Map<String, Object> body = response.as(new TypeRef<>() {
         });
-        Assertions.assertEquals("UP", body.get("status"));
 
         @SuppressWarnings("unchecked")
         List<Map<String, Object>> checks = (List<Map<String, Object>>) body.get("checks");

--- a/integration-tests/core/common/src/main/java/io/quarkus/it/artemis/core/common/ArtemisCoreProducerManager.java
+++ b/integration-tests/core/common/src/main/java/io/quarkus/it/artemis/core/common/ArtemisCoreProducerManager.java
@@ -23,7 +23,7 @@ public class ArtemisCoreProducerManager {
             try (ClientProducer producer = session.createProducer(queueName)) {
                 producer.send(message);
             }
-        } catch (ActiveMQException | NullPointerException e) {
+        } catch (ActiveMQException e) {
             throw new RuntimeException("Could not send message", e);
         }
     }

--- a/integration-tests/core/common/src/test/java/io/quarkus/it/artemis/core/common/ArtemisCoreHelper.java
+++ b/integration-tests/core/common/src/test/java/io/quarkus/it/artemis/core/common/ArtemisCoreHelper.java
@@ -1,6 +1,10 @@
 package io.quarkus.it.artemis.core.common;
 
+import static org.hamcrest.Matchers.is;
+
 import java.util.Random;
+
+import jakarta.ws.rs.core.Response;
 
 import org.apache.activemq.artemis.api.core.ActiveMQException;
 import org.apache.activemq.artemis.api.core.client.ActiveMQClient;
@@ -10,7 +14,6 @@ import org.eclipse.microprofile.config.ConfigProvider;
 import org.junit.jupiter.api.Assertions;
 
 import io.restassured.RestAssured;
-import io.restassured.response.Response;
 
 public class ArtemisCoreHelper {
     private static final Random RANDOM = new Random();
@@ -37,15 +40,21 @@ public class ArtemisCoreHelper {
             autoClosedSession.createProducer(addressName).send(message);
         }
 
-        Response response = RestAssured.with().get(endpoint);
-        Assertions.assertEquals(jakarta.ws.rs.core.Response.Status.OK.getStatusCode(), response.statusCode());
-        Assertions.assertEquals(body, response.getBody().asString());
+        // @formatter:off
+        RestAssured
+                .when().get(endpoint)
+                .then()
+                    .statusCode(Response.Status.OK.getStatusCode())
+                    .body(is(body));
+        // @formatter:on
     }
 
     public void receiveAndVerify(String endpoint, ClientSession session, String queueName) throws ActiveMQException {
         String body = createBody();
-        Response response = RestAssured.with().body(body).post(endpoint);
-        Assertions.assertEquals(jakarta.ws.rs.core.Response.Status.NO_CONTENT.getStatusCode(), response.statusCode());
+        RestAssured
+                .given().body(body)
+                .when().post(endpoint)
+                .then().statusCode(Response.Status.NO_CONTENT.getStatusCode());
 
         try (ClientSession autoClosedSession = session) {
             session.start();

--- a/integration-tests/jms/common/src/main/java/io/quarkus/it/artemis/jms/common/ArtemisJmsConsumerManager.java
+++ b/integration-tests/jms/common/src/main/java/io/quarkus/it/artemis/jms/common/ArtemisJmsConsumerManager.java
@@ -1,9 +1,12 @@
 package io.quarkus.it.artemis.jms.common;
 
+import java.util.Optional;
+
 import jakarta.jms.ConnectionFactory;
 import jakarta.jms.JMSConsumer;
 import jakarta.jms.JMSContext;
 import jakarta.jms.JMSException;
+import jakarta.jms.Message;
 
 public class ArtemisJmsConsumerManager {
     private final ConnectionFactory connectionFactory;
@@ -17,8 +20,13 @@ public class ArtemisJmsConsumerManager {
     public String receive() {
         try (JMSContext context = connectionFactory.createContext(JMSContext.AUTO_ACKNOWLEDGE);
                 JMSConsumer consumer = context.createConsumer(context.createQueue(queueName))) {
-            return consumer.receive(1000L).getBody(String.class);
-        } catch (JMSException | NullPointerException e) {
+            Optional<Message> maybeMessage = Optional.ofNullable(consumer.receive(1000L));
+            if (maybeMessage.isPresent()) {
+                return maybeMessage.get().getBody(String.class);
+            } else {
+                return null;
+            }
+        } catch (JMSException e) {
             throw new RuntimeException("Could not receive message", e);
         }
     }

--- a/integration-tests/jms/common/src/test/java/io/quarkus/it/artemis/jms/common/ArtemisJmsHelper.java
+++ b/integration-tests/jms/common/src/test/java/io/quarkus/it/artemis/jms/common/ArtemisJmsHelper.java
@@ -1,5 +1,7 @@
 package io.quarkus.it.artemis.jms.common;
 
+import static org.hamcrest.Matchers.is;
+
 import java.util.Random;
 
 import jakarta.jms.JMSConsumer;
@@ -77,15 +79,18 @@ public class ArtemisJmsHelper {
         }
 
         // Consume the message in xa transaction
-        Response response = RestAssured.with().get(xaEndpoint);
-        Assertions.assertEquals(jakarta.ws.rs.core.Response.Status.OK.getStatusCode(), response.statusCode());
-        Assertions.assertEquals(body, response.getBody().asString());
-
+        // @formatter:off
+        RestAssured
+                .when().get(xaEndpoint)
+                .then()
+                    .statusCode(jakarta.ws.rs.core.Response.Status.OK.getStatusCode())
+                    .body(is(body));
+        // @formatter:on
         // Receive from queue again to confirm nothing is received i.e. message was consumed
         // and now there is no message in the queue
-        response = RestAssured.with().get(endpoint);
-        Assertions.assertEquals(jakarta.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(),
-                response.statusCode());
+        RestAssured
+                .when().get(endpoint)
+                .then().statusCode(jakarta.ws.rs.core.Response.Status.NO_CONTENT.getStatusCode());
     }
 
     public void sendAndVerifyXARollback(JMSContext context, String queueName, String xaEndpoint, String endpoint) {


### PR DESCRIPTION
- When no message can be received, return null
- Where possible, rely on RestAssured