### PR TITLE
support additional activation specs in the config

### DIFF
--- a/ra/runtime/src/main/java/io/quarkus/artemis/jms/ra/ArtemisResourceAdapterFactory.java
+++ b/ra/runtime/src/main/java/io/quarkus/artemis/jms/ra/ArtemisResourceAdapterFactory.java
@@ -70,8 +70,13 @@ public class ArtemisResourceAdapterFactory implements ResourceAdapterFactory {
         activationSpec.setDestinationType(config.get("destination-type"));
         activationSpec.setDestination(config.get("destination"));
         activationSpec.setMaxSession(Integer.valueOf(config.getOrDefault("max-session", "5")));
+        activationSpec.setMessageSelector(config.get("message-selector"));
+        activationSpec.setShareSubscriptions(Boolean.valueOf(config.getOrDefault("share-subscriptions", "false")));
+        activationSpec.setSubscriptionDurability(config.get("durability"));
+        activationSpec.setSubscriptionName(config.get("subscription-name"));
         activationSpec.setRebalanceConnections(Boolean.valueOf(config.getOrDefault("rebalance-connections", "true")));
         activationSpec.setUseJNDI(false);
+
         return activationSpec;
     }
 


### PR DESCRIPTION
This supports additional activation spec properties mentioned in #400 

* messageSelector
* subscriptionDurability
* subscriptionName
* shareSubscriptions