### PR TITLE
Allow configuring a client id at the adapter level

### DIFF
--- a/docs/modules/ROOT/pages/quarkus-artemis-ra.adoc
+++ b/docs/modules/ROOT/pages/quarkus-artemis-ra.adoc
@@ -57,6 +57,7 @@ quarkus.ironjacamar.ra.config.connection-parameters=host=localhost;port=5445;pro
 quarkus.ironjacamar.ra.config.protocol-manager-factory=org.apache.activemq.artemis.core.protocol.hornetq.client.HornetQClientProtocolManagerFactory
 quarkus.ironjacamar.ra.config.user=guest
 quarkus.ironjacamar.ra.config.password=guest
+quarkus.ironjacamar.ra.config.client-id=Quarkus
 
 quarkus.ironjacamar.activation-spec.myqueue.config.destination-type=jakarta.jms.Queue <3>
 quarkus.ironjacamar.activation-spec.myqueue.config.destination=jms.queue.MyQueue

--- a/ra/runtime/src/main/java/io/quarkus/artemis/jms/ra/ArtemisResourceAdapterFactory.java
+++ b/ra/runtime/src/main/java/io/quarkus/artemis/jms/ra/ArtemisResourceAdapterFactory.java
@@ -49,6 +49,7 @@ public class ArtemisResourceAdapterFactory implements ResourceAdapterFactory {
         adapter.setUseJNDI(false);
         adapter.setUserName(config.get("user"));
         adapter.setPassword(config.get("password"));
+        adapter.setClientID(config.get("client-id"));
         adapter.setIgnoreJTA(false);
         return adapter;
     }


### PR DESCRIPTION
This allows setting the client id at the adapter level through the application.properties:

```
quarkus.ironjacamar.artemis.ra.config.client-id=Quarkus
```

Closes #427