### PR TITLE
The update to jandex 3.2.0 is scheduled for quarkus 3.12.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,6 +26,9 @@ updates:
       - dependency-name: "org.apache.activemq:*"
         versions:
           - "[2.33.0,)"
+      - dependency-name: "io.smallrye:jandex-maven-plugin"
+        versions:
+          - "[3.2.0,)"
     target-branch: "3.2.x"
   - package-ecosystem: "maven"
     directory: "/"
@@ -42,6 +45,9 @@ updates:
       - dependency-name: "io.quarkiverse.ironjacamar:*"
         versions:
           - "[1.2.0,)"
+      - dependency-name: "io.smallrye:jandex-maven-plugin"
+        versions:
+          - "[3.2.0,)"
     target-branch: "3.1.x"
   - package-ecosystem: "maven"
     directory: "/"
@@ -61,20 +67,7 @@ updates:
       - dependency-name: "io.quarkiverse.ironjacamar:*"
         versions:
           - "[1.2.0,)"
+      - dependency-name: "io.smallrye:jandex-maven-plugin"
+        versions:
+          - "[3.2.0,)"
     target-branch: "3.0.x"
-  - package-ecosystem: "maven"
-    directory: "/"
-    schedule:
-      interval: "daily"
-    ignore:
-      - dependency-name: "org.apache.maven.plugins:maven-compiler-plugin"
-      - dependency-name: "io.quarkus:*"
-        versions:
-          - "[3.0,)"
-      - dependency-name: "io.quarkus.platform:quarkus-camel-bom"
-        versions:
-          - "[3.0,)"
-      - dependency-name: "io.quarkiverse:quarkiverse-parent"
-        versions:
-          - "[16,)"
-    target-branch: "2.x"


### PR DESCRIPTION
All prior versions need to stay on jandex 3.1.x.