### PR TITLE
Maintenance

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/artemis/core/deployment/DevServicesArtemisProcessor.java
+++ b/core/deployment/src/main/java/io/quarkus/artemis/core/deployment/DevServicesArtemisProcessor.java
@@ -139,7 +139,7 @@ public class DevServicesArtemisProcessor {
                     }
                 } catch (Throwable t) {
                     compressor.closeAndDumpCaptured();
-                    throw t instanceof RuntimeException ? (RuntimeException) t : new RuntimeException(t);
+                    throw t instanceof RuntimeException runtimeException ? runtimeException : new RuntimeException(t);
                 }
             }
         }
@@ -188,8 +188,8 @@ public class DevServicesArtemisProcessor {
         if (devServices.get(name) != null) {
             try {
                 devServices.get(name).close();
-            } catch (Throwable e) {
-                LOGGER.error("Failed to stop the ActiveMQ Artemis broker", e);
+            } catch (Throwable t) {
+                LOGGER.error("Failed to stop the ActiveMQ Artemis broker", t);
             } finally {
                 devServices.remove(name);
             }
@@ -219,7 +219,7 @@ public class DevServicesArtemisProcessor {
             return null;
         }
 
-        if (!dockerStatusBuildItem.isDockerAvailable()) {
+        if (!dockerStatusBuildItem.isContainerRuntimeAvailable()) {
             LOGGER.warn(
                     "Docker isn't working, please configure the ActiveMQ Artemis Url property (quarkus.artemis.url).");
             return null;

--- a/core/runtime/src/main/java/io/quarkus/artemis/core/runtime/ArtemisDevServicesBuildTimeConfig.java
+++ b/core/runtime/src/main/java/io/quarkus/artemis/core/runtime/ArtemisDevServicesBuildTimeConfig.java
@@ -58,7 +58,7 @@ public interface ArtemisDevServicesBuildTimeConfig {
     Optional<String> user();
 
     /**
-     * Password to start artemis broker. Defaults to {@code admin} whne not set.
+     * Password to start artemis broker. Defaults to {@code admin} when not set.
      */
     Optional<String> password();
 

--- a/core/runtime/src/main/java/io/quarkus/artemis/core/runtime/ArtemisUtil.java
+++ b/core/runtime/src/main/java/io/quarkus/artemis/core/runtime/ArtemisUtil.java
@@ -51,8 +51,7 @@ public class ArtemisUtil {
 
     private static String extractIdentifier(InstanceHandle<?> handle) {
         for (Annotation qualifier : handle.getBean().getQualifiers()) {
-            if (qualifier instanceof Identifier) {
-                Identifier identifier = (Identifier) qualifier;
+            if (qualifier instanceof Identifier identifier) {
                 return identifier.value();
             }
         }

--- a/integration-tests/ra/src/main/java/io/quarkus/it/artemis/ra/JcaResource.java
+++ b/integration-tests/ra/src/main/java/io/quarkus/it/artemis/ra/JcaResource.java
@@ -1,9 +1,9 @@
 package io.quarkus.it.artemis.ra;
 
 import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.inject.Inject;
 import jakarta.jms.ConnectionFactory;
 import jakarta.jms.JMSContext;
+import jakarta.jms.JMSException;
 import jakarta.jms.JMSProducer;
 import jakarta.jms.Queue;
 import jakarta.jms.TextMessage;
@@ -21,10 +21,11 @@ import io.quarkus.narayana.jta.QuarkusTransaction;
 @Path("/jca")
 @ApplicationScoped
 public class JcaResource {
-    // add some rest methods here
+    private final ConnectionFactory factory;
 
-    @Inject
-    ConnectionFactory factory;
+    public JcaResource(@SuppressWarnings("CdiInjectionPointsInspection") ConnectionFactory factory) {
+        this.factory = factory;
+    }
 
     @GET
     @Transactional
@@ -46,7 +47,7 @@ public class JcaResource {
     @POST
     @Transactional
     @Path("/sales")
-    public void sendToSalesQueue(@FormParam("name") String name) throws Exception {
+    public void sendToSalesQueue(@FormParam("name") String name) throws JMSException {
         try (JMSContext context = factory.createContext()) {
             JMSProducer producer = context.createProducer();
             TextMessage msg = context.createTextMessage(name);
@@ -72,7 +73,7 @@ public class JcaResource {
     @GET
     @Path("/transacted")
     @Transactional
-    public boolean Transacted() {
+    public boolean transacted() {
         return isTransacted();
     }
 

--- a/integration-tests/ra/src/main/java/io/quarkus/it/artemis/ra/MyQueueMessageEndpoint.java
+++ b/integration-tests/ra/src/main/java/io/quarkus/it/artemis/ra/MyQueueMessageEndpoint.java
@@ -18,8 +18,7 @@ import io.quarkus.narayana.jta.QuarkusTransaction;
 @ResourceEndpoint(activationSpecConfigKey = "myqueue")
 @Path("/myqueue")
 public class MyQueueMessageEndpoint implements MessageListener {
-
-    AtomicInteger counter = new AtomicInteger(0);
+    private final AtomicInteger counter = new AtomicInteger(0);
 
     @Override
     @Transactional

--- a/integration-tests/ra/src/main/java/io/quarkus/it/artemis/ra/SalesEndpoint.java
+++ b/integration-tests/ra/src/main/java/io/quarkus/it/artemis/ra/SalesEndpoint.java
@@ -3,7 +3,6 @@ package io.quarkus.it.artemis.ra;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.inject.Inject;
 import jakarta.jms.ConnectionFactory;
 import jakarta.jms.JMSContext;
 import jakarta.jms.Message;
@@ -17,11 +16,14 @@ import io.quarkus.narayana.jta.QuarkusTransaction;
 @ApplicationScoped
 @ResourceEndpoint(activationSpecConfigKey = "sales")
 public class SalesEndpoint implements MessageListener {
+    private final ConnectionFactory connectionFactory;
+    private final AtomicInteger count;
 
-    @Inject
-    ConnectionFactory connectionFactory;
-
-    AtomicInteger count = new AtomicInteger(0);
+    public SalesEndpoint(
+            @SuppressWarnings("CdiInjectionPointsInspection") ConnectionFactory connectionFactory) {
+        this.connectionFactory = connectionFactory;
+        count = new AtomicInteger(0);
+    }
 
     @Override
     @Transactional

--- a/integration-tests/ra/src/test/java/io/quarkus/it/artemis/ra/InjectionTest.java
+++ b/integration-tests/ra/src/test/java/io/quarkus/it/artemis/ra/InjectionTest.java
@@ -15,18 +15,18 @@ import io.quarkus.test.junit.TestProfile;
 
 @QuarkusTest
 @TestProfile(DisableAllServices.class)
-public class InjectionTest {
-
+class InjectionTest {
     @Inject
+    @SuppressWarnings("CdiInjectionPointsInspection")
     ConnectionFactory connectionFactory;
 
     @Test
-    public void testProducer() {
+    void testProducer() {
         assertThat(Arc.container().listAll(IronJacamarContainer.class)).hasSize(1);
     }
 
     @Test
-    public void shouldInjectConnectionFactory() {
+    void shouldInjectConnectionFactory() {
         assertThat(Arc.container().listAll(ConnectionFactory.class)).hasSize(1);
         assertThat(connectionFactory).isNotNull();
     }

--- a/integration-tests/ra/src/test/java/io/quarkus/it/artemis/ra/IronJacamarConfigTest.java
+++ b/integration-tests/ra/src/test/java/io/quarkus/it/artemis/ra/IronJacamarConfigTest.java
@@ -13,22 +13,20 @@ import io.quarkus.test.junit.TestProfile;
 
 @QuarkusTest
 @TestProfile(DisableDataBaseService.class)
-public class IronJacamarConfigTest {
-
+class IronJacamarConfigTest {
     @Inject
     IronJacamarRuntimeConfig runtimeConfig;
 
     @Test
     void shouldReadConfig() {
         assertThat(runtimeConfig.resourceAdapters().get("<default>").ra()).satisfies(
-                ra -> {
-                    assertThat(ra.config()).hasEntrySatisfying("connection-parameters", cp -> {
-                        assertThat(cp).matches("host=localhost;port=[0-9]+;protocols=AMQP");
-                    });
-                });
-        assertThat(runtimeConfig.activationSpecs().map().get("myqueue").config()).hasEntrySatisfying("destination", d -> {
-            assertThat(d).endsWith("MyQueue");
-        });
+                ra -> assertThat(ra.config())
+                        .hasEntrySatisfying(
+                                "connection-parameters",
+                                cp -> assertThat(cp)
+                                        .matches("host=localhost;port=[0-9]+;protocols=AMQP")));
+        assertThat(runtimeConfig.activationSpecs().map().get("myqueue").config())
+                .hasEntrySatisfying("destination", d -> assertThat(d).endsWith("MyQueue"));
 
     }
 }

--- a/integration-tests/ra/src/test/java/io/quarkus/it/artemis/ra/JcaResourceIT.java
+++ b/integration-tests/ra/src/test/java/io/quarkus/it/artemis/ra/JcaResourceIT.java
@@ -3,5 +3,5 @@ package io.quarkus.it.artemis.ra;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 
 @QuarkusIntegrationTest
-public class JcaResourceIT extends JcaResourceTest {
+class JcaResourceIT extends JcaResourceTest {
 }

--- a/integration-tests/ra/src/test/java/io/quarkus/it/artemis/ra/JcaResourceTest.java
+++ b/integration-tests/ra/src/test/java/io/quarkus/it/artemis/ra/JcaResourceTest.java
@@ -2,7 +2,6 @@ package io.quarkus.it.artemis.ra;
 
 import static org.hamcrest.Matchers.is;
 
-import jakarta.transaction.Transactional;
 import jakarta.ws.rs.core.Response;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -15,26 +14,21 @@ import io.restassured.RestAssured;
 
 @QuarkusTest
 @QuarkusTestResource(ArtemisTestResource.class)
-public class JcaResourceTest {
-
+class JcaResourceTest {
     @BeforeEach
-    @Transactional
     void setup() {
         // @formatter:off
         RestAssured
                 .when().delete("/jca/gifts")
-                .then()
-                .statusCode(Response.Status.NO_CONTENT.getStatusCode());
+                .then().statusCode(Response.Status.NO_CONTENT.getStatusCode());
         RestAssured
                 .when().put("/myqueue/reset")
-                .then()
-                    .statusCode(Response.Status.NO_CONTENT.getStatusCode());
+                .then().statusCode(Response.Status.NO_CONTENT.getStatusCode());
         // @formatter:on
     }
 
     @Test
-    @Transactional
-    public void testProducer() {
+    void testProducer() {
         // @formatter:off
         RestAssured
                 .when().get("/jca?name=George")
@@ -55,14 +49,13 @@ public class JcaResourceTest {
     }
 
     @Test
-    @Transactional
-    public void testProducerRollback() {
+    void testProducerRollback() {
         // @formatter:off
         RestAssured
                 .when().get("/jca?name=rollback")
                 .then()
                     .statusCode(Response.Status.OK.getStatusCode())
-                .   body(is("Hello rollback"));
+                    .body(is("Hello rollback"));
         RestAssured
                 .when().get("/jca/gifts/count")
                 .then()
@@ -71,12 +64,13 @@ public class JcaResourceTest {
         RestAssured
                 .when().get("/myqueue")
                 .then()
-                    .statusCode(Response.Status.OK.getStatusCode()).body(is("0"));
+                    .statusCode(Response.Status.OK.getStatusCode())
+                    .body(is("0"));
         // @formatter:on
     }
 
     @Test
-    public void testTransacted() {
+    void testTransacted() {
         // @formatter:off
         RestAssured
                 .when().get("/jca/transacted")
@@ -87,7 +81,7 @@ public class JcaResourceTest {
     }
 
     @Test
-    public void testNotTransacted() {
+    void testNotTransacted() {
         // @formatter:off
         RestAssured
                 .when().get("/jca/not-transacted")

--- a/integration-tests/ra/src/test/java/io/quarkus/it/artemis/ra/MetricsTest.java
+++ b/integration-tests/ra/src/test/java/io/quarkus/it/artemis/ra/MetricsTest.java
@@ -13,15 +13,14 @@ import io.restassured.RestAssured;
 
 @QuarkusTest
 @TestProfile(DisableAllServices.class)
-public class MetricsTest {
-
+class MetricsTest {
     @Test
     void shouldHaveMetrics() {
         // @formatter:off
         RestAssured
                 .when().get("/q/metrics")
                 .then()
-                .log().ifValidationFails()
+                    .log().ifValidationFails()
                     .statusCode(Response.Status.OK.getStatusCode())
                     .body(containsString("ironjacamar_pool_in_use_count_total{resourceAdapter=\"<default>\"}"));
         // @formatter:on

--- a/integration-tests/ra/src/test/java/io/quarkus/it/artemis/ra/TransactionTest.java
+++ b/integration-tests/ra/src/test/java/io/quarkus/it/artemis/ra/TransactionTest.java
@@ -17,23 +17,21 @@ import io.restassured.RestAssured;
 
 @QuarkusTest
 @QuarkusTestResource(ArtemisTestResource.class)
-public class TransactionTest {
-
+class TransactionTest {
     @Inject
+    @SuppressWarnings("CdiInjectionPointsInspection")
     ConnectionFactory factory;
 
     @Inject
     SalesEndpoint endpoint;
 
     @Test
-    public void retryMessagesOnRollback() {
+    void retryMessagesOnRollback() {
         // @formatter:off
         RestAssured
-                .given()
-                .formParam("name", "George")
+                .given().formParam("name", "George")
                 .when().post("/jca/sales")
-                .then()
-                    .statusCode(Response.Status.NO_CONTENT.getStatusCode());
+                .then().statusCode(Response.Status.NO_CONTENT.getStatusCode());
         // @formatter:on
 
         try (JMSContext context = factory.createContext()) {

--- a/jms/runtime/src/main/java/io/quarkus/artemis/jms/runtime/ArtemisJmsRecorder.java
+++ b/jms/runtime/src/main/java/io/quarkus/artemis/jms/runtime/ArtemisJmsRecorder.java
@@ -36,11 +36,11 @@ public class ArtemisJmsRecorder {
         return () -> connectionFactory;
     }
 
-    private ConnectionFactory extractConnectionFactory(boolean isXAenabled, ArtemisRuntimeConfig runtimeConfig,
+    private ConnectionFactory extractConnectionFactory(boolean isXaEnabled, ArtemisRuntimeConfig runtimeConfig,
             Function<ConnectionFactory, Object> wrapper) {
         String url = runtimeConfig.getUrl();
         if (url != null) {
-            if (isXAenabled) {
+            if (isXaEnabled) {
                 return (ConnectionFactory) wrapper.apply(new ActiveMQXAConnectionFactory(
                         url,
                         runtimeConfig.getUsername(),


### PR DESCRIPTION
- Change deprecated dockerStatusBuildItem.isDockerAvailable() to dockerStatusBuildItem.isContainerRuntimeAvailable()
- Resource Adapter integration tests:
  - Where possible, use constructor injection
  - Remove public modifier from all test classes and -method
  - Reformat code
- Fix typos