### PR TITLE
#623: Restructure pipeline so PR runs from forks succeed.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,21 +24,27 @@ on:
       - '*.txt'
       - '.all-contributorsrc'
 
-permissions:
-  actions: write
-  checks: write
-  pull-requests: write
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  recreate-comment:
+  upload-pr-number:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Publish Report
-        uses: turing85/publish-report@v2
+      - name: Get
+        id: get-pr-number
+        if: ${{ always() && github.event_name == 'pull_request' }}
+        run: |
+          echo "${{ github.event.number }}" > "pr-number.txt"
+
+      - name: Upload
+        uses: actions/upload-artifact@v4
+        if: ${{ always() && github.event_name == 'pull_request' }}
         with:
-          checkout: 'true'
-          recreate-comment: true
+          name: pr-number
+          path: pr-number.txt
 
   generate-matrix:
     runs-on: ubuntu-latest
@@ -175,23 +181,6 @@ jobs:
           if-no-files-found: error
           retention-days: 2
 
-  test-report-jvm:
-    runs-on: ubuntu-latest
-
-    needs:
-      - recreate-comment
-      - build-and-test-jvm
-
-    steps:
-      - name: Publish Report
-        uses: turing85/publish-report@v2
-        with:
-          checkout: 'true'
-          download-artifact-pattern: test-report-jvm-*
-          download-artifact-merge-multiple: true
-          report-name: JUnit JVM Test
-          report-path: '**/target/surefire-reports/TEST*.xml'
-
   build-and-test-native:
     runs-on: ubuntu-latest
 
@@ -249,21 +238,3 @@ jobs:
           path: '**/target/*-reports/TEST*.xml'
           if-no-files-found: error
           retention-days: 2
-
-  test-report-native:
-    runs-on: ubuntu-latest
-
-    needs:
-      - recreate-comment
-      - build-and-test-native
-
-    steps:
-      - name: Publish Report
-        if: ${{ always() }}
-        uses: turing85/publish-report@v2
-        with:
-          checkout: 'true'
-          download-artifact-pattern: test-report-native-*
-          download-artifact-merge-multiple: true
-          report-name: JUnit Native Test
-          report-path: '**/target/*-reports/TEST*.xml'

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -1,0 +1,35 @@
+name: Comment on PR
+
+on:
+  pull_request_target:
+    paths-ignore:
+      - '.gitignore'
+      - 'CODEOWNERS'
+      - 'LICENSE'
+      - '*.md'
+      - '*.adoc'
+      - '*.txt'
+      - '.all-contributorsrc'
+
+permissions:
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  comment:
+    name: Create PR comment
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: (Re)create comment
+        uses: turing85/publish-report@v2
+        with:
+          github-token: ${{ github.token }}
+          comment-message-recreate: |
+            ## 🚦Reports 🚦
+            Reports will be posted here as they get available.
+          comment-message-pr-number: ${{ github.event.number }}
+          recreate-comment: true

--- a/.github/workflows/pr-report.yml
+++ b/.github/workflows/pr-report.yml
@@ -1,0 +1,78 @@
+name: Post test reports to PR
+
+on:
+  workflow_run:
+    workflows:
+      - "build"
+    types:
+      - completed
+
+permissions:
+  checks: write
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  report:
+    name: Post Test reports
+    if: ${{ github.event.workflow_run.event == 'pull_request' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download PR number
+        uses: actions/download-artifact@v4
+        with:
+          github-token: ${{ github.token }}
+          name: pr-number
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Set PR number
+        id: set-pr-number
+        run: |
+          echo "pr-number=$(cat pr-number.txt)" >> "${GITHUB_OUTPUT}"
+
+      - name: Override comment
+        if: ${{ always() }}
+        uses: turing85/publish-report@v2
+        with:
+          override-comment: true
+          comment-message-override: |
+            ## 🚦Reports for run [#${{ github.event.workflow_run.run_number }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }})🚦
+            Reports will be posted here as they get available.
+          comment-message-pr-number: ${{ steps.set-pr-number.outputs.pr-number }}
+
+      - name: Tabula rasa
+        if: ${{ always() }}
+        run: rm -rf *
+
+      - name: Publish Report JVM
+        if: ${{ always() }}
+        uses: turing85/publish-report@v2
+
+        with:
+          checkout: true
+          comment-message-pr-number: ${{ steps.set-pr-number.outputs.pr-number }}
+          download-artifact-pattern: test-report-jvm-*
+          download-artifact-merge-multiple: true
+          download-artifact-run-id: ${{ github.event.workflow_run.id }}
+          report-name: JUnit JVM Test
+          report-path: '**/target/*-reports/TEST*.xml'
+
+      - name: Tabula rasa
+        if: ${{ always() }}
+        run: rm -rf *
+
+      - name: Publish Report Native
+        if: ${{ always() }}
+        uses: turing85/publish-report@v2
+        with:
+          checkout: true
+          comment-message-pr-number: ${{ steps.set-pr-number.outputs.pr-number }}
+          download-artifact-pattern: test-report-native-*
+          download-artifact-merge-multiple: true
+          download-artifact-run-id: ${{ github.event.workflow_run.id }}
+          report-name: JUnit Native Test
+          report-path: '**/target/*-reports/TEST*.xml'


### PR DESCRIPTION
Resolves #623.

Please do not be surprised. For the changes to take full effect, the workflows `pr-comment.yml` and `pr-report.yml` need to be on the default branch.

The final result will be virtually indistinguishable from the current behaviour, see https://github.com/turing85/quarkus-artemis/pull/2#issuecomment-2339250938