### PR TITLE
Use and document Artemis BOM, fixes #437

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -52,6 +52,14 @@
 
             <dependency>
                 <groupId>org.apache.activemq</groupId>
+                <artifactId>artemis-bom</artifactId>
+                <version>${artemis.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.activemq</groupId>
                 <artifactId>artemis-core-client</artifactId>
                 <version>${artemis.version}</version>
                 <exclusions>
@@ -101,11 +109,6 @@
                         <artifactId>commons-logging</artifactId>
                     </exclusion>
                 </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.activemq</groupId>
-                <artifactId>artemis-jakarta-ra</artifactId>
-                <version>${artemis.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.activemq</groupId>

--- a/docs/modules/ROOT/pages/includes/attributes.adoc
+++ b/docs/modules/ROOT/pages/includes/attributes.adoc
@@ -1,4 +1,4 @@
-:quarkus-version: 3.16.1
+:quarkus-version: 3.17.4
 :quarkus-artemis-version: 3.6.0
 
 :quarkus-org-url: https://github.com/quarkusio

--- a/docs/modules/ROOT/pages/quarkus-artemis-jms.adoc
+++ b/docs/modules/ROOT/pages/quarkus-artemis-jms.adoc
@@ -138,16 +138,23 @@ it is recommended to add the following BOM to your project, *below the Quarkus B
 <dependencyManagement>
     <dependencies>
         <dependency>
+            <groupId>org.apache.activemq</groupId>
+            <artifactId>artemis-bom</artifactId>
+            <version>${artemis-version}</version>
+            <type>pom</type>
+            <scope>import</scope>
+        </dependency>
+        <dependency>
             <groupId>io.quarkus.platform</groupId>
             <artifactId>quarkus-bom</artifactId>
-            <version>${quarkus.version}</version>
+            <version>${quarkus-version}</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>
         <dependency>
             <groupId>io.quarkiverse.artemis</groupId>
             <artifactId>quarkus-artemis-bom</artifactId>
-            <version>{quarkus-artemis-version}</version>
+            <version>${quarkus-artemis-version}</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>
@@ -170,7 +177,8 @@ Once the BOM is added, simply add the `io.quarkiverse.artemis:quarkus-artemis-jm
 </dependency>
 ----
 
-We recommend to set properties `quarkus.version` and `artemis.version` to the versions you are using/need to use. We also recommend to align `artemis.version` with the artemis server version used.
+We recommend to set properties `quarkus.version` and `artemis.version` to the versions you are using/need to use.
+We also recommend to align `artemis.version` with the artemis server version used.
 
 If you are using `camel-quarkus`, we also recommend setting `camel-quarkus.platform.version` to the version of camel used.
 

--- a/docs/modules/ROOT/pages/quarkus-artemis-ra.adoc
+++ b/docs/modules/ROOT/pages/quarkus-artemis-ra.adoc
@@ -16,16 +16,23 @@ it is recommended to add the following BOM to your project, *below the Quarkus B
 <dependencyManagement>
     <dependencies>
         <dependency>
+            <groupId>org.apache.activemq</groupId>
+            <artifactId>artemis-bom</artifactId>
+            <version>${artemis-version}</version>
+            <type>pom</type>
+            <scope>import</scope>
+        </dependency>
+        <dependency>
             <groupId>io.quarkus.platform</groupId>
             <artifactId>quarkus-bom</artifactId>
-            <version>${quarkus.version}</version>
+            <version>${quarkus-version}</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>
         <dependency>
             <groupId>io.quarkiverse.artemis</groupId>
             <artifactId>quarkus-artemis-bom</artifactId>
-            <version>{quarkus-artemis-version}</version>
+            <version>${quarkus-artemis-version}</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>
@@ -43,7 +50,9 @@ Once the BOM is added, simply add the `io.quarkiverse.artemis:quarkus-artemis-ra
 </dependency>
 ----
 
-We recommend to set properties `quarkus.version` and `artemis.version` to the versions you are using/need to use. We also recommend to align `artemis.version` with the artemis server version used.
+We recommend to set properties `quarkus.version` and `artemis.version` to the versions you are using/need to use.
+We also recommend to align `artemis.version` with the artemis server version used.
+
 
 == Configuration
 


### PR DESCRIPTION
Also changed the `quarkus.version` into `quarkus-version` to align with Quarkus itself. And fix the `$` of `quarkus-artemis-version`.

Resolves #437 