### PR TITLE
Bump artemis-image from 2.38.0 to 2.39.0.

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/artemis/core/runtime/ArtemisDevServicesBuildTimeConfig.java
+++ b/core/runtime/src/main/java/io/quarkus/artemis/core/runtime/ArtemisDevServicesBuildTimeConfig.java
@@ -22,7 +22,7 @@ public interface ArtemisDevServicesBuildTimeConfig {
     /**
      * The ActiveMQ Artemis container image to use.
      * <p>
-     * Defaults to {@code quay.io/artemiscloud/activemq-artemis-broker:artemis.2.38.0}
+     * Defaults to {@code quay.io/arkmq-org/activemq-artemis-broker:artemis.2.39.0}
      */
     Optional<String> imageName();
 
@@ -77,7 +77,7 @@ public interface ArtemisDevServicesBuildTimeConfig {
     }
 
     default String getImageName() {
-        return imageName().orElse("quay.io/artemiscloud/activemq-artemis-broker:artemis.2.38.0");
+        return imageName().orElse("quay.io/arkmq-org/activemq-artemis-broker:artemis.2.39.0");
     }
 
     default boolean isShared() {

--- a/docs/modules/ROOT/pages/includes/attributes.adoc
+++ b/docs/modules/ROOT/pages/includes/attributes.adoc
@@ -1,4 +1,4 @@
-:quarkus-version: 3.17.4
+:quarkus-version: 3.17.7
 :quarkus-artemis-version: 3.6.0
 
 :quarkus-org-url: https://github.com/quarkusio

--- a/docs/modules/ROOT/pages/includes/quarkus-artemis-core.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-artemis-core.adoc
@@ -116,7 +116,7 @@ a|icon:lock[title=Fixed at build time] [[quarkus-artemis-core_quarkus-artemis-de
 --
 The ActiveMQ Artemis container image to use.
 
-Defaults to `quay.io/artemiscloud/activemq-artemis-broker:artemis.2.38.0`
+Defaults to `quay.io/arkmq-org/activemq-artemis-broker:artemis.2.39.0`
 
 
 ifdef::add-copy-button-to-env-var[]

--- a/docs/modules/ROOT/pages/includes/quarkus-artemis-core_quarkus.artemis.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-artemis-core_quarkus.artemis.adoc
@@ -116,7 +116,7 @@ a|icon:lock[title=Fixed at build time] [[quarkus-artemis-core_quarkus-artemis-de
 --
 The ActiveMQ Artemis container image to use.
 
-Defaults to `quay.io/artemiscloud/activemq-artemis-broker:artemis.2.38.0`
+Defaults to `quay.io/arkmq-org/activemq-artemis-broker:artemis.2.39.0`
 
 
 ifdef::add-copy-button-to-env-var[]


### PR DESCRIPTION
This also means switching from quay.io/artemiscloud to quay.io/arkmq-org.