### PR TITLE
Add support for exposing the Artemis Web-Ui

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/artemis/core/deployment/DevServicesArtemisProcessor.java
+++ b/core/deployment/src/main/java/io/quarkus/artemis/core/deployment/DevServicesArtemisProcessor.java
@@ -18,12 +18,8 @@ import io.quarkus.artemis.core.runtime.ArtemisDevServicesBuildTimeConfig;
 import io.quarkus.artemis.core.runtime.ArtemisUtil;
 import io.quarkus.deployment.IsNormal;
 import io.quarkus.deployment.annotations.BuildStep;
-import io.quarkus.deployment.builditem.CuratedApplicationShutdownBuildItem;
-import io.quarkus.deployment.builditem.DevServicesResultBuildItem;
+import io.quarkus.deployment.builditem.*;
 import io.quarkus.deployment.builditem.DevServicesResultBuildItem.RunningDevService;
-import io.quarkus.deployment.builditem.DevServicesSharedNetworkBuildItem;
-import io.quarkus.deployment.builditem.DockerStatusBuildItem;
-import io.quarkus.deployment.builditem.LaunchModeBuildItem;
 import io.quarkus.deployment.console.ConsoleInstalledBuildItem;
 import io.quarkus.deployment.console.StartupLogCompressor;
 import io.quarkus.deployment.dev.devservices.DevServicesConfig;
@@ -305,9 +301,14 @@ public class DevServicesArtemisProcessor {
     }
 
     private static String mergeExtraArgs(String defaultExtraArgs, String extraArgs) {
-        List<String> paramsToAdd = Arrays.stream(defaultExtraArgs.split(" "))
-                .filter(da -> !extraArgs.contains(da)).toList();
+        List<String> parsedDefaultArgs = Arrays.asList(defaultExtraArgs.split(" "));
 
+        List<String> duplicatedParams = parsedDefaultArgs.stream().filter(extraArgs::contains).toList();
+        if (!duplicatedParams.isEmpty()) {
+            LOGGER.warnf("parameters %s are set in both default-extra-args and extra-args", duplicatedParams);
+        }
+
+        List<String> paramsToAdd = parsedDefaultArgs.stream().filter(p -> !duplicatedParams.contains(p)).toList();
         return String.join(" ", paramsToAdd) + (paramsToAdd.isEmpty() ? "" : " ") + extraArgs;
     }
 

--- a/core/deployment/src/main/java/io/quarkus/artemis/core/deployment/DevServicesArtemisProcessor.java
+++ b/core/deployment/src/main/java/io/quarkus/artemis/core/deployment/DevServicesArtemisProcessor.java
@@ -267,7 +267,7 @@ public class DevServicesArtemisProcessor {
                     config.webUiPort,
                     config.user,
                     config.password,
-                    config.extraArgs);
+                    mergeExtraArgs(config.defaultExtraArgs, config.extraArgs));
 
             ConfigureUtil.configureSharedNetwork(container, "artemis");
 
@@ -304,6 +304,13 @@ public class DevServicesArtemisProcessor {
         return null;
     }
 
+    private static String mergeExtraArgs(String defaultExtraArgs, String extraArgs) {
+        List<String> paramsToAdd = Arrays.stream(defaultExtraArgs.split(" "))
+                .filter(da -> !extraArgs.contains(da)).toList();
+
+        return String.join(" ", paramsToAdd) + (paramsToAdd.isEmpty() ? "" : " ") + extraArgs;
+    }
+
     private static final class ArtemisDevServiceCfg {
         private final boolean devServicesEnabled;
         private final String imageName;
@@ -314,6 +321,7 @@ public class DevServicesArtemisProcessor {
         private final String user;
         private final String password;
         private final String extraArgs;
+        private final String defaultExtraArgs;
 
         public ArtemisDevServiceCfg(ArtemisBuildTimeConfig config, String name, boolean isUrlEmpty) {
             ArtemisDevServicesBuildTimeConfig devServicesConfig = config.getDevservices();
@@ -326,6 +334,7 @@ public class DevServicesArtemisProcessor {
             this.user = devServicesConfig.getUser();
             this.password = devServicesConfig.getPassword();
             this.extraArgs = devServicesConfig.getExtraArgs();
+            this.defaultExtraArgs = devServicesConfig.getDefaultExtraArgs();
         }
 
         @Override

--- a/core/runtime/src/main/java/io/quarkus/artemis/core/runtime/ArtemisDevServicesBuildTimeConfig.java
+++ b/core/runtime/src/main/java/io/quarkus/artemis/core/runtime/ArtemisDevServicesBuildTimeConfig.java
@@ -71,7 +71,7 @@ public interface ArtemisDevServicesBuildTimeConfig {
 
     /**
      * The value of the {@code AMQ_EXTRA_ARGS} environment variable to pass to the container. Defaults to
-     * {@code --no-autotune --mapped --no-fsync} when not set.
+     * {@code --no-autotune --mapped --no-fsync  --relax-jolokia} when not set.
      */
     Optional<String> extraArgs();
 
@@ -108,7 +108,7 @@ public interface ArtemisDevServicesBuildTimeConfig {
     }
 
     default String getExtraArgs() {
-        return extraArgs().orElse("--no-autotune --mapped --no-fsync");
+        return extraArgs().orElse("--no-autotune --mapped --no-fsync --relax-jolokia");
     }
 
     default boolean isEmpty() {

--- a/core/runtime/src/main/java/io/quarkus/artemis/core/runtime/ArtemisDevServicesBuildTimeConfig.java
+++ b/core/runtime/src/main/java/io/quarkus/artemis/core/runtime/ArtemisDevServicesBuildTimeConfig.java
@@ -20,6 +20,13 @@ public interface ArtemisDevServicesBuildTimeConfig {
     Optional<Integer> port();
 
     /**
+     * Optional fixed port the Artemis Web-Ui will be exposed at.
+     * <p>
+     * If not defined, the Artemis Web-Ui port will be chosen randomly.
+     */
+    Optional<Integer> webUiPort();
+
+    /**
      * The ActiveMQ Artemis container image to use.
      * <p>
      * Defaults to {@code quay.io/arkmq-org/activemq-artemis-broker:artemis.2.39.0}
@@ -74,6 +81,10 @@ public interface ArtemisDevServicesBuildTimeConfig {
 
     default int getPort() {
         return port().orElse(0);
+    }
+
+    default int getWebUiPort() {
+        return webUiPort().orElse(0);
     }
 
     default String getImageName() {

--- a/core/runtime/src/main/java/io/quarkus/artemis/core/runtime/ArtemisDevServicesBuildTimeConfig.java
+++ b/core/runtime/src/main/java/io/quarkus/artemis/core/runtime/ArtemisDevServicesBuildTimeConfig.java
@@ -70,10 +70,18 @@ public interface ArtemisDevServicesBuildTimeConfig {
     Optional<String> password();
 
     /**
-     * The value of the {@code AMQ_EXTRA_ARGS} environment variable to pass to the container. Defaults to
-     * {@code --no-autotune --mapped --no-fsync  --relax-jolokia} when not set.
+     * Value to pass into the {@code AMQ_EXTRA_ARGS} environment variable in the container. Values wil be augmented with those
+     * provided in {@code defaultExtraArgs}
      */
     Optional<String> extraArgs();
+
+    /**
+     * Default values to be merged with those provided in {@code extraArgs}. It's recommended to only overwrite this if one of
+     * the below listed default arguments needs to be unset, otherwise the {@code extraArgs} option should be used.
+     * <p>
+     * Defaults to {@code --no-autotune --mapped --no-fsync --relax-jolokia} when not set.
+     */
+    Optional<String> defaultExtraArgs();
 
     default boolean isEnabled() {
         return enabled().orElse(true);
@@ -108,7 +116,11 @@ public interface ArtemisDevServicesBuildTimeConfig {
     }
 
     default String getExtraArgs() {
-        return extraArgs().orElse("--no-autotune --mapped --no-fsync --relax-jolokia");
+        return extraArgs().orElse("");
+    }
+
+    default String getDefaultExtraArgs() {
+        return defaultExtraArgs().orElse("--no-autotune --mapped --no-fsync --relax-jolokia");
     }
 
     default boolean isEmpty() {
@@ -119,6 +131,7 @@ public interface ArtemisDevServicesBuildTimeConfig {
                 && serviceName().isEmpty()
                 && user().isEmpty()
                 && password().isEmpty()
-                && extraArgs().isEmpty();
+                && extraArgs().isEmpty()
+                && defaultExtraArgs().isEmpty();
     }
 }


### PR DESCRIPTION
### Context
While using this Project and its provided Dev-Services I noticed that the Artemis web-ui (8161) is not exposed.
Since this is a feature I would find convenient I decided to build a version that would support it 

Other Dev-Services (Quarkus AMQP) do expose the Web-Ui, I was therefore curios if maybe this Project also has an Interested in adding the feature into its code base as well.

### Description
This PR now exposes the Artemis-Web-Ui (Port 8161) per default at a random port. 
Using the optional "web-ui-port" property a fixed port on which to expose the Ui can be defined.

### Changes in the Codebase
- Add the Optional Parameter `webUiPort` into the `ArtemisDevServicesBuildTimeConfig`
- Add `ARTEMIS_WEB_UI_PORT` to the exposed ports when building the `ArtemisContainer`
- Add the fixed exposed port (if set) when the  configuration is called

### If there is an Interested in this, i would like to kindly ask:
- if you could nudge me in the right direction towards how you would like to test this feature. (A quick "web-ui" can be reached via http request? Or something more in depth?)
- if you could nudge me towards how the documentation can be updated (I noticed the adoc files seem to usually just updated with the ci pipeline?)

### Considerations
This PR tries to keep the behavior of the `web-ui-port` property the same as `port`. Maybe it could also make sense to not expose 8161 per default (to keep the dev-services current behavior) and only expose them when explicitly set.

Thanks a lot for your time and for making this project!

PS: This is my second ever public PR, I kindly ask for feedback should there be any mistakes/breach of common protocol
