### PR TITLE
Support Compose DevService

### DIFF
--- a/docs/modules/ROOT/pages/quarkus-artemis-ra.adoc
+++ b/docs/modules/ROOT/pages/quarkus-artemis-ra.adoc
@@ -123,6 +123,26 @@ public class MyResourceEndpoint implements MessageListener {
 <1> This MessageListener will be activated by the `other` resource adapter configured above.
 <2> This `ConnectionFactory` will be the one configured in the `main` resource adapter.
 
+[[Compose]]
+== Compose
+
+The Artemis RA Dev Services supports xref:https://quarkus.io/guides/compose-dev-services[Compose Dev Services].
+It relies on a `compose-devservices.yml`, such as:
+
+[source,yaml]
+----
+name: <application name>
+services:
+  artemis:
+    image: quay.io/arkmq-org/activemq-artemis-broker:artemis.2.40.0
+    ports:
+      - "61616"
+    environment:
+      AMQ_USER: admin
+      AMQ_PASSWORD: admin
+      AMQ_EXTRA_ARGS: --no-autotune --mapped --no-fsync
+----
+
 
 [[extension-configuration-reference]]
 == Configuration Reference


### PR DESCRIPTION
This brings some support for compose dev service in artemis jms RA.
I left 3 `TODO` with open questions. I would like your advice @ozangunalp 
I used apicurio as an example to bring those modifications from this [commit](https://github.com/quarkusio/quarkus/pull/46848/files#diff-a95c1e07d280f4aa2a52da9dc054fd1941c07ec5020ba046b0c75052d1ba7314)
I have tested with:
```
name: my-app
services:
  artemis:
    image: quay.io/arkmq-org/activemq-artemis-broker:artemis.2.40.0
    ports:
      - "61616"
    environment:
      AMQ_USER: admin
      AMQ_PASSWORD: admin
      AMQ_EXTRA_ARGS: --no-autotune --mapped --no-fsync
    labels:
      io.quarkus.devservices.compose.wait_for.ports.disable: true
      io.quarkus.devservices.compose.wait_for.logs: .*AMQ241004.*
```
this works fine. if the compose container is started, it gets picked up. if not, a regular container will be launched.
see https://quarkus.io/guides/compose-dev-services