### PR TITLE
Revert "Bump quarkus-ironjacamar.version from 1.5.6 to 1.6.0"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         <artemis.version>2.40.0</artemis.version>
         <camel-quarkus.platform.version>3.20.1</camel-quarkus.platform.version>
         <quarkus.version>3.20.1</quarkus.version>
-        <quarkus-ironjacamar.version>1.6.0</quarkus-ironjacamar.version>
+        <quarkus-ironjacamar.version>1.5.6</quarkus-ironjacamar.version>
 
         <!-- Project setup -->
         <maven.compiler.parameters>true</maven.compiler.parameters>


### PR DESCRIPTION
Reverts quarkiverse/quarkus-artemis#840

Merge was an accident. We should not bump the version on an LTS branch.