### PR TITLE
Do not use Runtime configuration during deployment

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/artemis/core/deployment/ArtemisCoreProcessor.java
+++ b/core/deployment/src/main/java/io/quarkus/artemis/core/deployment/ArtemisCoreProcessor.java
@@ -28,7 +28,6 @@ import org.jboss.logging.Logger;
 import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
 import io.quarkus.artemis.core.runtime.ArtemisBuildTimeConfigs;
 import io.quarkus.artemis.core.runtime.ArtemisCoreRecorder;
-import io.quarkus.artemis.core.runtime.ArtemisRuntimeConfigs;
 import io.quarkus.artemis.core.runtime.ArtemisUtil;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
@@ -137,7 +136,6 @@ public class ArtemisCoreProcessor {
     @BuildStep
     ArtemisCoreConfiguredBuildItem configure(
             ArtemisCoreRecorder recorder,
-            ArtemisRuntimeConfigs runtimeConfigs,
             ShadowRuntimeConfigs shadowRunTimeConfigs,
             ArtemisBuildTimeConfigs buildTimeConfigs,
             ArtemisBootstrappedBuildItem bootstrap,
@@ -157,10 +155,7 @@ public class ArtemisCoreProcessor {
                     && buildTimeConfigs.configs().get(name).isEmpty()) {
                 continue;
             }
-            Supplier<ServerLocator> supplier = recorder.getServerLocatorSupplier(
-                    name,
-                    runtimeConfigs,
-                    buildTimeConfigs);
+            Supplier<ServerLocator> supplier = recorder.getServerLocatorSupplier(name);
             SyntheticBeanBuildItem serverLocator = toSyntheticBeanBuildItem(supplier, name, isSoleServerLocator);
             syntheticBeanProducer.produce(serverLocator);
         }

--- a/core/runtime/src/main/java/io/quarkus/artemis/core/runtime/ArtemisCoreRecorder.java
+++ b/core/runtime/src/main/java/io/quarkus/artemis/core/runtime/ArtemisCoreRecorder.java
@@ -6,15 +6,21 @@ import java.util.function.Supplier;
 import org.apache.activemq.artemis.api.core.client.ActiveMQClient;
 import org.apache.activemq.artemis.api.core.client.ServerLocator;
 
+import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
 
 @Recorder
 public class ArtemisCoreRecorder {
-    public Supplier<ServerLocator> getServerLocatorSupplier(
-            String name,
-            ArtemisRuntimeConfigs runtimeConfigs,
-            ArtemisBuildTimeConfigs buildTimeConfigs) {
-        ArtemisRuntimeConfig runtimeConfig = runtimeConfigs.configs().get(name);
+    private final ArtemisBuildTimeConfigs buildTimeConfigs;
+    private final RuntimeValue<ArtemisRuntimeConfigs> runtimeConfigs;
+
+    public ArtemisCoreRecorder(ArtemisBuildTimeConfigs buildTimeConfigs, RuntimeValue<ArtemisRuntimeConfigs> runtimeConfigs) {
+        this.buildTimeConfigs = buildTimeConfigs;
+        this.runtimeConfigs = runtimeConfigs;
+    }
+
+    public Supplier<ServerLocator> getServerLocatorSupplier(String name) {
+        ArtemisRuntimeConfig runtimeConfig = runtimeConfigs.getValue().configs().get(name);
         ArtemisBuildTimeConfig buildTimeConfig = buildTimeConfigs.configs().get(name);
         ArtemisUtil.validateIntegrity(name, runtimeConfig, buildTimeConfig);
         ServerLocator serverLocator = Objects.requireNonNull(getServerLocator(runtimeConfig.getUrl()));

--- a/jms/deployment/src/main/java/io/quarkus/artemis/jms/deployment/ArtemisJmsProcessor.java
+++ b/jms/deployment/src/main/java/io/quarkus/artemis/jms/deployment/ArtemisJmsProcessor.java
@@ -18,7 +18,6 @@ import io.quarkus.artemis.core.deployment.ArtemisCoreProcessor;
 import io.quarkus.artemis.core.deployment.ArtemisJmsBuildItem;
 import io.quarkus.artemis.core.deployment.ShadowRuntimeConfigs;
 import io.quarkus.artemis.core.runtime.ArtemisBuildTimeConfigs;
-import io.quarkus.artemis.core.runtime.ArtemisRuntimeConfigs;
 import io.quarkus.artemis.jms.runtime.ArtemisJmsRecorder;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
@@ -49,7 +48,6 @@ public class ArtemisJmsProcessor {
     @BuildStep
     ArtemisJmsConfiguredBuildItem configure(
             ArtemisJmsRecorder recorder,
-            ArtemisRuntimeConfigs runtimeConfigs,
             ShadowRuntimeConfigs shadowRunTimeConfigs,
             ArtemisBuildTimeConfigs buildTimeConfigs,
             ArtemisBootstrappedBuildItem bootstrap,
@@ -66,11 +64,7 @@ public class ArtemisJmsProcessor {
             if (!shadowRunTimeConfigs.getNames().contains(name) && buildTimeConfigs.configs().get(name).isEmpty()) {
                 continue;
             }
-            Supplier<ConnectionFactory> connectionFactorySupplier = recorder.getConnectionFactoryProducer(
-                    name,
-                    runtimeConfigs,
-                    buildTimeConfigs,
-                    wrapper);
+            Supplier<ConnectionFactory> connectionFactorySupplier = recorder.getConnectionFactoryProducer(name, wrapper);
             syntheticBeanProducer.produce(toSyntheticBeanBuildItem(
                     connectionFactorySupplier,
                     name,

--- a/jms/runtime/src/main/java/io/quarkus/artemis/jms/runtime/ArtemisJmsRecorder.java
+++ b/jms/runtime/src/main/java/io/quarkus/artemis/jms/runtime/ArtemisJmsRecorder.java
@@ -14,21 +14,25 @@ import io.quarkus.artemis.core.runtime.ArtemisBuildTimeConfigs;
 import io.quarkus.artemis.core.runtime.ArtemisRuntimeConfig;
 import io.quarkus.artemis.core.runtime.ArtemisRuntimeConfigs;
 import io.quarkus.artemis.core.runtime.ArtemisUtil;
+import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
 
 @Recorder
 public class ArtemisJmsRecorder {
+    private final ArtemisBuildTimeConfigs buildTimeConfigs;
+    private final RuntimeValue<ArtemisRuntimeConfigs> runtimeConfigs;
+
+    public ArtemisJmsRecorder(ArtemisBuildTimeConfigs buildTimeConfigs, RuntimeValue<ArtemisRuntimeConfigs> runtimeConfigs) {
+        this.buildTimeConfigs = buildTimeConfigs;
+        this.runtimeConfigs = runtimeConfigs;
+    }
 
     public Function<ConnectionFactory, Object> getDefaultWrapper() {
         return cf -> cf;
     }
 
-    public Supplier<ConnectionFactory> getConnectionFactoryProducer(
-            String name,
-            ArtemisRuntimeConfigs runtimeConfigs,
-            ArtemisBuildTimeConfigs buildTimeConfigs,
-            Function<ConnectionFactory, Object> wrapper) {
-        ArtemisRuntimeConfig runtimeConfig = runtimeConfigs.configs().get(name);
+    public Supplier<ConnectionFactory> getConnectionFactoryProducer(String name, Function<ConnectionFactory, Object> wrapper) {
+        ArtemisRuntimeConfig runtimeConfig = runtimeConfigs.getValue().configs().get(name);
         ArtemisBuildTimeConfig buildTimeConfig = buildTimeConfigs.configs().get(name);
         ArtemisUtil.validateIntegrity(name, runtimeConfig, buildTimeConfig);
         final ConnectionFactory connectionFactory = Objects


### PR DESCRIPTION
With https://github.com/quarkusio/quarkus/pull/48500, we will disallow the injection of Runtime configuration objects during deployment. The recommended way is to inject it directly into the Recorder wrapped into a `RuntimeValue`.