### PR TITLE
#954: add flag property `quarkus.artemis.health.fail.log` to (de-)activate health check failure logging

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/artemis/core/runtime/ArtemisRuntimeConfigs.java
+++ b/core/runtime/src/main/java/io/quarkus/artemis/core/runtime/ArtemisRuntimeConfigs.java
@@ -40,6 +40,13 @@ public interface ArtemisRuntimeConfigs {
     Optional<Boolean> healthExternalEnabled();
 
     /**
+     * Whether failed health checks should report the stack trace via a log.
+     */
+    @WithName("health.fail.log")
+    @WithDefault("true")
+    boolean healthFailLog();
+
+    /**
      * The log level for the stack trace of a failed health check.
      * <p>
      * If the log level is not enabled, the health check will only report {@code "DOWN"}.

--- a/core/runtime/src/main/java/io/quarkus/artemis/core/runtime/ArtemisUtil.java
+++ b/core/runtime/src/main/java/io/quarkus/artemis/core/runtime/ArtemisUtil.java
@@ -84,9 +84,8 @@ public class ArtemisUtil {
     }
 
     public static void handleFailedHealthCheck(HealthCheckResponseBuilder builder, String connectionKind, String name,
-            Logger logger,
-            Logger.Level logLevel, Throwable t) {
-        if (logger.isEnabled(logLevel)) {
+            Logger logger, boolean doLog, Logger.Level logLevel, Throwable t) {
+        if (doLog && logger.isEnabled(logLevel)) {
             String errorId = UUID.randomUUID().toString();
             MDC.put(ERROR_ID_KEY, errorId);
             logger.log(logLevel,

--- a/core/runtime/src/main/java/io/quarkus/artemis/core/runtime/health/ServerLocatorHealthCheck.java
+++ b/core/runtime/src/main/java/io/quarkus/artemis/core/runtime/health/ServerLocatorHealthCheck.java
@@ -51,7 +51,7 @@ public class ServerLocatorHealthCheck implements HealthCheck {
             try (ClientSessionFactory ignored = serverLocators.select(identifier).get().createSessionFactory()) {
                 builder.withData(name, "UP");
             } catch (Exception e) {
-                ArtemisUtil.handleFailedHealthCheck(builder, "server locator", name, LOGGER,
+                ArtemisUtil.handleFailedHealthCheck(builder, "server locator", name, LOGGER, runtimeConfigs.healthFailLog(),
                         runtimeConfigs.healthFailLogLevel(), e);
             }
         }

--- a/docs/modules/ROOT/pages/quarkus-artemis-jms.adoc
+++ b/docs/modules/ROOT/pages/quarkus-artemis-jms.adoc
@@ -525,7 +525,7 @@ Caused by: org.apache.activemq.artemis.api.core.ActiveMQNotConnectedException: [
 ----
 ====
 
-If log level `quarkus.artemis.health.fail.log-level` is not active, then the failing health check will have only the data `"DOWN"`, and no message is logged.
+If log level `quarkus.artemis.health.fail.log-level` is not active or `quarkus.artemis.health.fail.log` is set to `false` (it defaults to `true`), then the failing health check will have only the data `"DOWN"`, and no message is logged.
 
 .Sample health response on error without `error-id`
 [%collapsible]

--- a/jms/runtime/src/main/java/io/quarkus/artemis/jms/runtime/health/ConnectionFactoryHealthCheck.java
+++ b/jms/runtime/src/main/java/io/quarkus/artemis/jms/runtime/health/ConnectionFactoryHealthCheck.java
@@ -52,7 +52,7 @@ public class ConnectionFactoryHealthCheck implements HealthCheck {
             try (Connection ignored = connectionFactories.select(identifier).get().createConnection()) {
                 builder.withData(name, "UP");
             } catch (Exception e) {
-                ArtemisUtil.handleFailedHealthCheck(builder, "connection factory", name, LOGGER,
+                ArtemisUtil.handleFailedHealthCheck(builder, "connection factory", name, LOGGER, runtimeConfigs.healthFailLog(),
                         runtimeConfigs.healthFailLogLevel(), e);
             }
         }

--- a/ra/runtime/src/main/java/io/quarkus/artemis/jms/ra/runtime/ConnectionFactoryHealthCheck.java
+++ b/ra/runtime/src/main/java/io/quarkus/artemis/jms/ra/runtime/ConnectionFactoryHealthCheck.java
@@ -45,7 +45,7 @@ public class ConnectionFactoryHealthCheck implements HealthCheck {
             try (Connection ignored = connectionFactories.select(identifier).get().createConnection()) {
                 builder.withData(name, "UP");
             } catch (Exception e) {
-                ArtemisUtil.handleFailedHealthCheck(builder, "connection factory", name, LOGGER,
+                ArtemisUtil.handleFailedHealthCheck(builder, "connection factory", name, LOGGER, runtimeConfigs.healthFailLog(),
                         runtimeConfigs.healthFailLogLevel(), e);
             }
         }


### PR DESCRIPTION
Belongs to #954 