### PR TITLE
Enable parallel build, e.g. with mvnd.

### DIFF
--- a/integration-tests/camel-jms/with-default-and-named/src/main/resources/application.properties
+++ b/integration-tests/camel-jms/with-default-and-named/src/main/resources/application.properties
@@ -1,3 +1,8 @@
 quarkus.artemis.devservices.enabled=false
 quarkus.artemis."named".devservices.enabled=false
 quarkus.artemis."named".health-exclude=true
+
+quarkus.http.test-port=0
+
+quarkus.log.category."org.apache.activemq.audit".level=WARN
+quarkus.log.category."org.apache.activemq.artemis.core.server".level=WARN

--- a/integration-tests/camel-jms/with-default-and-named/src/test/resources/broker-named.xml
+++ b/integration-tests/camel-jms/with-default-and-named/src/test/resources/broker-named.xml
@@ -6,10 +6,10 @@
         <large-messages-directory>./target/artemis/named/large-messages</large-messages-directory>
 
         <connectors>
-            <connector name="activemq">tcp://localhost:61617</connector>
+            <connector name="activemq">tcp://localhost:0</connector>
         </connectors>
         <acceptors>
-            <acceptor name="activemq">tcp://localhost:61617</acceptor>
+            <acceptor name="activemq">tcp://localhost:0</acceptor>
         </acceptors>
 
         <max-disk-usage>-1</max-disk-usage>

--- a/integration-tests/camel-jms/with-default-and-named/src/test/resources/broker.xml
+++ b/integration-tests/camel-jms/with-default-and-named/src/test/resources/broker.xml
@@ -6,10 +6,10 @@
         <large-messages-directory>./target/artemis/default/large-messages</large-messages-directory>
 
         <connectors>
-            <connector name="activemq">tcp://localhost:61616</connector>
+            <connector name="activemq">tcp://localhost:0</connector>
         </connectors>
         <acceptors>
-            <acceptor name="activemq">tcp://localhost:61616</acceptor>
+            <acceptor name="activemq">tcp://localhost:0</acceptor>
         </acceptors>
 
         <max-disk-usage>-1</max-disk-usage>

--- a/integration-tests/camel-jms/with-default/src/main/resources/application.properties
+++ b/integration-tests/camel-jms/with-default/src/main/resources/application.properties
@@ -1,1 +1,6 @@
 quarkus.artemis.devservices.enabled=false
+
+quarkus.http.test-port=0
+
+quarkus.log.category."org.apache.activemq.audit".level=WARN
+quarkus.log.category."org.apache.activemq.artemis.core.server".level=WARN

--- a/integration-tests/camel-jms/with-default/src/test/resources/broker.xml
+++ b/integration-tests/camel-jms/with-default/src/test/resources/broker.xml
@@ -6,10 +6,10 @@
         <large-messages-directory>./target/artemis/default/large-messages</large-messages-directory>
 
         <connectors>
-            <connector name="activemq">tcp://localhost:61616</connector>
+            <connector name="activemq">tcp://localhost:0</connector>
         </connectors>
         <acceptors>
-            <acceptor name="activemq">tcp://localhost:61616</acceptor>
+            <acceptor name="activemq">tcp://localhost:0</acceptor>
         </acceptors>
 
         <max-disk-usage>-1</max-disk-usage>

--- a/integration-tests/camel-jms/with-external/src/main/resources/application.properties
+++ b/integration-tests/camel-jms/with-external/src/main/resources/application.properties
@@ -1,1 +1,6 @@
 artemis.externally-defined.url=tcp://dummy
+
+quarkus.http.test-port=0
+
+quarkus.log.category."org.apache.activemq.audit".level=WARN
+quarkus.log.category."org.apache.activemq.artemis.core.server".level=WARN

--- a/integration-tests/camel-jms/with-external/src/test/resources/broker-externally-defined.xml
+++ b/integration-tests/camel-jms/with-external/src/test/resources/broker-externally-defined.xml
@@ -6,10 +6,10 @@
         <large-messages-directory>./target/artemis/external/large-messages</large-messages-directory>
 
         <connectors>
-            <connector name="activemq">tcp://localhost:61618</connector>
+            <connector name="activemq">tcp://localhost:0</connector>
         </connectors>
         <acceptors>
-            <acceptor name="activemq">tcp://localhost:61618</acceptor>
+            <acceptor name="activemq">tcp://localhost:0</acceptor>
         </acceptors>
 
         <max-disk-usage>-1</max-disk-usage>

--- a/integration-tests/camel-jms/with-named-and-external/src/main/resources/application.properties
+++ b/integration-tests/camel-jms/with-named-and-external/src/main/resources/application.properties
@@ -1,2 +1,7 @@
 quarkus.artemis."named".devservices.enabled=false
 artemis.externally-defined.url=tcp://dummy
+
+quarkus.http.test-port=0
+
+quarkus.log.category."org.apache.activemq.audit".level=WARN
+quarkus.log.category."org.apache.activemq.artemis.core.server".level=WARN

--- a/integration-tests/camel-jms/with-named-and-external/src/test/resources/broker-externally-defined.xml
+++ b/integration-tests/camel-jms/with-named-and-external/src/test/resources/broker-externally-defined.xml
@@ -6,10 +6,10 @@
         <large-messages-directory>./target/artemis/external/large-messages</large-messages-directory>
 
         <connectors>
-            <connector name="activemq">tcp://localhost:61618</connector>
+            <connector name="activemq">tcp://localhost:0</connector>
         </connectors>
         <acceptors>
-            <acceptor name="activemq">tcp://localhost:61618</acceptor>
+            <acceptor name="activemq">tcp://localhost:0</acceptor>
         </acceptors>
 
         <max-disk-usage>-1</max-disk-usage>

--- a/integration-tests/camel-jms/with-named-and-external/src/test/resources/broker-named.xml
+++ b/integration-tests/camel-jms/with-named-and-external/src/test/resources/broker-named.xml
@@ -6,10 +6,10 @@
         <large-messages-directory>./target/artemis/named/large-messages</large-messages-directory>
 
         <connectors>
-            <connector name="activemq">tcp://localhost:61617</connector>
+            <connector name="activemq">tcp://localhost:0</connector>
         </connectors>
         <acceptors>
-            <acceptor name="activemq">tcp://localhost:61617</acceptor>
+            <acceptor name="activemq">tcp://localhost:0</acceptor>
         </acceptors>
 
         <max-disk-usage>-1</max-disk-usage>

--- a/integration-tests/camel-jms/with-named/src/main/resources/application.properties
+++ b/integration-tests/camel-jms/with-named/src/main/resources/application.properties
@@ -1,1 +1,6 @@
 quarkus.artemis."named".devservices.enabled=false
+
+quarkus.http.test-port=0
+
+quarkus.log.category."org.apache.activemq.audit".level=WARN
+quarkus.log.category."org.apache.activemq.artemis.core.server".level=WARN

--- a/integration-tests/camel-jms/with-named/src/test/resources/broker-named.xml
+++ b/integration-tests/camel-jms/with-named/src/test/resources/broker-named.xml
@@ -6,10 +6,10 @@
         <large-messages-directory>./target/artemis/named/large-messages</large-messages-directory>
 
         <connectors>
-            <connector name="activemq">tcp://localhost:61617</connector>
+            <connector name="activemq">tcp://localhost:0</connector>
         </connectors>
         <acceptors>
-            <acceptor name="activemq">tcp://localhost:61617</acceptor>
+            <acceptor name="activemq">tcp://localhost:0</acceptor>
         </acceptors>
 
         <max-disk-usage>-1</max-disk-usage>

--- a/integration-tests/core/empty-config/src/main/resources/application.properties
+++ b/integration-tests/core/empty-config/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+quarkus.http.test-port=0

--- a/integration-tests/core/with-default-and-external/src/main/resources/application.properties
+++ b/integration-tests/core/with-default-and-external/src/main/resources/application.properties
@@ -2,3 +2,8 @@ quarkus.artemis.devservices.enabled=false
 quarkus.artemis."named-1".devservices.enabled=false
 quarkus.artemis."named-2".enabled=false
 artemis.externally-defined.url=tcp://dummy
+
+quarkus.http.test-port=0
+
+quarkus.log.category."org.apache.activemq.audit".level=WARN
+quarkus.log.category."org.apache.activemq.artemis.core.server".level=WARN

--- a/integration-tests/core/with-default-and-external/src/test/resources/broker-externally-defined.xml
+++ b/integration-tests/core/with-default-and-external/src/test/resources/broker-externally-defined.xml
@@ -6,10 +6,10 @@
         <large-messages-directory>./target/artemis/externally-defined/large-messages</large-messages-directory>
 
         <connectors>
-            <connector name="activemq">tcp://localhost:61618</connector>
+            <connector name="activemq">tcp://localhost:0</connector>
         </connectors>
         <acceptors>
-            <acceptor name="activemq">tcp://localhost:61618</acceptor>
+            <acceptor name="activemq">tcp://localhost:0</acceptor>
         </acceptors>
 
         <max-disk-usage>-1</max-disk-usage>

--- a/integration-tests/core/with-default-and-external/src/test/resources/broker-named-1.xml
+++ b/integration-tests/core/with-default-and-external/src/test/resources/broker-named-1.xml
@@ -6,10 +6,10 @@
         <large-messages-directory>./target/artemis/named-1/large-messages</large-messages-directory>
 
         <connectors>
-            <connector name="activemq">tcp://localhost:61617</connector>
+            <connector name="activemq">tcp://localhost:0</connector>
         </connectors>
         <acceptors>
-            <acceptor name="activemq">tcp://localhost:61617</acceptor>
+            <acceptor name="activemq">tcp://localhost:0</acceptor>
         </acceptors>
 
         <max-disk-usage>-1</max-disk-usage>

--- a/integration-tests/core/with-default-and-external/src/test/resources/broker.xml
+++ b/integration-tests/core/with-default-and-external/src/test/resources/broker.xml
@@ -6,10 +6,10 @@
         <large-messages-directory>./target/artemis/default/large-messages</large-messages-directory>
 
         <connectors>
-            <connector name="activemq">tcp://localhost:61616</connector>
+            <connector name="activemq">tcp://localhost:0</connector>
         </connectors>
         <acceptors>
-            <acceptor name="activemq">tcp://localhost:61616</acceptor>
+            <acceptor name="activemq">tcp://localhost:0</acceptor>
         </acceptors>
 
         <max-disk-usage>-1</max-disk-usage>

--- a/integration-tests/core/with-default-change-url/src/main/resources/application.properties
+++ b/integration-tests/core/with-default-change-url/src/main/resources/application.properties
@@ -3,3 +3,8 @@ quarkus.artemis.devservices.enabled=false
 quarkus.artemis."named-1".url=tcp://dummy-1:23456
 quarkus.artemis."named-1".devservices.enabled=false
 quarkus.artemis."named-2".enabled=false
+
+quarkus.http.test-port=0
+
+quarkus.log.category."org.apache.activemq.audit".level=WARN
+quarkus.log.category."org.apache.activemq.artemis.core.server".level=WARN

--- a/integration-tests/core/with-default-change-url/src/test/resources/broker-named-1.xml
+++ b/integration-tests/core/with-default-change-url/src/test/resources/broker-named-1.xml
@@ -6,10 +6,10 @@
         <large-messages-directory>./target/artemis/named-1/large-messages</large-messages-directory>
 
         <connectors>
-            <connector name="activemq">tcp://localhost:61617</connector>
+            <connector name="activemq">tcp://localhost:0</connector>
         </connectors>
         <acceptors>
-            <acceptor name="activemq">tcp://localhost:61617</acceptor>
+            <acceptor name="activemq">tcp://localhost:0</acceptor>
         </acceptors>
 
         <max-disk-usage>-1</max-disk-usage>

--- a/integration-tests/core/with-default-change-url/src/test/resources/broker.xml
+++ b/integration-tests/core/with-default-change-url/src/test/resources/broker.xml
@@ -6,10 +6,10 @@
         <large-messages-directory>./target/artemis/default/large-messages</large-messages-directory>
 
         <connectors>
-            <connector name="activemq">tcp://localhost:61616</connector>
+            <connector name="activemq">tcp://localhost:0</connector>
         </connectors>
         <acceptors>
-            <acceptor name="activemq">tcp://localhost:61616</acceptor>
+            <acceptor name="activemq">tcp://localhost:0</acceptor>
         </acceptors>
 
         <max-disk-usage>-1</max-disk-usage>

--- a/integration-tests/core/with-default-dynamic-port/src/main/resources/application.properties
+++ b/integration-tests/core/with-default-dynamic-port/src/main/resources/application.properties
@@ -2,3 +2,8 @@ quarkus.artemis.devservices.enabled=false
 quarkus.artemis.health-exclude=true
 quarkus.artemis."named-1".devservices.enabled=false
 quarkus.artemis."named-2".enabled=false
+
+quarkus.http.test-port=0
+
+quarkus.log.category."org.apache.activemq.audit".level=WARN
+quarkus.log.category."org.apache.activemq.artemis.core.server".level=WARN

--- a/integration-tests/core/with-default/src/main/resources/application.properties
+++ b/integration-tests/core/with-default/src/main/resources/application.properties
@@ -2,3 +2,8 @@ quarkus.artemis.devservices.enabled=false
 quarkus.artemis.health-exclude=true
 quarkus.artemis."named-1".devservices.enabled=false
 quarkus.artemis."named-2".enabled=false
+
+quarkus.http.test-port=0
+
+quarkus.log.category."org.apache.activemq.audit".level=WARN
+quarkus.log.category."org.apache.activemq.artemis.core.server".level=WARN

--- a/integration-tests/core/with-default/src/test/resources/broker-named-1.xml
+++ b/integration-tests/core/with-default/src/test/resources/broker-named-1.xml
@@ -6,10 +6,10 @@
         <large-messages-directory>./target/artemis/named-1/large-messages</large-messages-directory>
 
         <connectors>
-            <connector name="activemq">tcp://localhost:61617</connector>
+            <connector name="activemq">tcp://localhost:0</connector>
         </connectors>
         <acceptors>
-            <acceptor name="activemq">tcp://localhost:61617</acceptor>
+            <acceptor name="activemq">tcp://localhost:0</acceptor>
         </acceptors>
 
         <max-disk-usage>-1</max-disk-usage>

--- a/integration-tests/core/with-default/src/test/resources/broker.xml
+++ b/integration-tests/core/with-default/src/test/resources/broker.xml
@@ -6,10 +6,10 @@
         <large-messages-directory>./target/artemis/default/large-messages</large-messages-directory>
 
         <connectors>
-            <connector name="activemq">tcp://localhost:61616</connector>
+            <connector name="activemq">tcp://localhost:0</connector>
         </connectors>
         <acceptors>
-            <acceptor name="activemq">tcp://localhost:61616</acceptor>
+            <acceptor name="activemq">tcp://localhost:0</acceptor>
         </acceptors>
 
         <max-disk-usage>-1</max-disk-usage>

--- a/integration-tests/core/with-external/src/main/resources/application.properties
+++ b/integration-tests/core/with-external/src/main/resources/application.properties
@@ -1,0 +1,4 @@
+quarkus.http.test-port=0
+
+quarkus.log.category."org.apache.activemq.audit".level=WARN
+quarkus.log.category."org.apache.activemq.artemis.core.server".level=WARN

--- a/integration-tests/core/with-external/src/test/resources/broker-externally-defined.xml
+++ b/integration-tests/core/with-external/src/test/resources/broker-externally-defined.xml
@@ -6,10 +6,10 @@
         <large-messages-directory>./target/artemis/externally-defined/large-messages</large-messages-directory>
 
         <connectors>
-            <connector name="activemq">tcp://localhost:61618</connector>
+            <connector name="activemq">tcp://localhost:0</connector>
         </connectors>
         <acceptors>
-            <acceptor name="activemq">tcp://localhost:61618</acceptor>
+            <acceptor name="activemq">tcp://localhost:0</acceptor>
         </acceptors>
 
         <max-disk-usage>-1</max-disk-usage>

--- a/integration-tests/core/with-external/src/test/resources/broker-named-1.xml
+++ b/integration-tests/core/with-external/src/test/resources/broker-named-1.xml
@@ -6,10 +6,10 @@
         <large-messages-directory>./target/artemis/named-1/large-messages</large-messages-directory>
 
         <connectors>
-            <connector name="activemq">tcp://localhost:61617</connector>
+            <connector name="activemq">tcp://localhost:0</connector>
         </connectors>
         <acceptors>
-            <acceptor name="activemq">tcp://localhost:61617</acceptor>
+            <acceptor name="activemq">tcp://localhost:0</acceptor>
         </acceptors>
 
         <max-disk-usage>-1</max-disk-usage>

--- a/integration-tests/core/with-external/src/test/resources/broker.xml
+++ b/integration-tests/core/with-external/src/test/resources/broker.xml
@@ -6,10 +6,10 @@
         <large-messages-directory>./target/artemis/default/large-messages</large-messages-directory>
 
         <connectors>
-            <connector name="activemq">tcp://localhost:61616</connector>
+            <connector name="activemq">tcp://localhost:0</connector>
         </connectors>
         <acceptors>
-            <acceptor name="activemq">tcp://localhost:61616</acceptor>
+            <acceptor name="activemq">tcp://localhost:0</acceptor>
         </acceptors>
 
         <max-disk-usage>-1</max-disk-usage>

--- a/integration-tests/core/without-default/src/main/resources/application.properties
+++ b/integration-tests/core/without-default/src/main/resources/application.properties
@@ -1,2 +1,7 @@
 quarkus.artemis."named-1".devservices.enabled=false
 quarkus.artemis."named-2".enabled=false
+
+quarkus.http.test-port=0
+
+quarkus.log.category."org.apache.activemq.audit".level=WARN
+quarkus.log.category."org.apache.activemq.artemis.core.server".level=WARN

--- a/integration-tests/core/without-default/src/test/resources/broker-named-1.xml
+++ b/integration-tests/core/without-default/src/test/resources/broker-named-1.xml
@@ -6,10 +6,10 @@
         <large-messages-directory>./target/artemis/named-1/large-messages</large-messages-directory>
 
         <connectors>
-            <connector name="activemq">tcp://localhost:61617</connector>
+            <connector name="activemq">tcp://localhost:0</connector>
         </connectors>
         <acceptors>
-            <acceptor name="activemq">tcp://localhost:61617</acceptor>
+            <acceptor name="activemq">tcp://localhost:0</acceptor>
         </acceptors>
 
         <max-disk-usage>-1</max-disk-usage>

--- a/integration-tests/jms/empty-config/src/main/resources/application.properties
+++ b/integration-tests/jms/empty-config/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+quarkus.http.test-port=0

--- a/integration-tests/jms/with-default-and-external/src/main/resources/application.properties
+++ b/integration-tests/jms/with-default-and-external/src/main/resources/application.properties
@@ -4,4 +4,8 @@ quarkus.artemis."named-1".devservices.enabled=false
 quarkus.artemis."named-1".xa-enabled=true
 quarkus.artemis."named-2".enabled=false
 artemis.externally-defined.url=tcp://dummy
+
+quarkus.http.test-port=0
+
 quarkus.log.category."org.apache.activemq.audit".level=WARN
+quarkus.log.category."org.apache.activemq.artemis.core.server".level=WARN

--- a/integration-tests/jms/with-default-and-external/src/test/resources/broker-externally-defined.xml
+++ b/integration-tests/jms/with-default-and-external/src/test/resources/broker-externally-defined.xml
@@ -6,10 +6,10 @@
         <large-messages-directory>./target/artemis/externally-defined/large-messages</large-messages-directory>
 
         <connectors>
-            <connector name="activemq">tcp://localhost:61618</connector>
+            <connector name="activemq">tcp://localhost:0</connector>
         </connectors>
         <acceptors>
-            <acceptor name="activemq">tcp://localhost:61618</acceptor>
+            <acceptor name="activemq">tcp://localhost:0</acceptor>
         </acceptors>
 
         <max-disk-usage>-1</max-disk-usage>

--- a/integration-tests/jms/with-default-and-external/src/test/resources/broker-named-1.xml
+++ b/integration-tests/jms/with-default-and-external/src/test/resources/broker-named-1.xml
@@ -6,10 +6,10 @@
         <large-messages-directory>./target/artemis/named-1/large-messages</large-messages-directory>
 
         <connectors>
-            <connector name="activemq">tcp://localhost:61617</connector>
+            <connector name="activemq">tcp://localhost:0</connector>
         </connectors>
         <acceptors>
-            <acceptor name="activemq">tcp://localhost:61617</acceptor>
+            <acceptor name="activemq">tcp://localhost:0</acceptor>
         </acceptors>
 
         <max-disk-usage>-1</max-disk-usage>

--- a/integration-tests/jms/with-default-and-external/src/test/resources/broker.xml
+++ b/integration-tests/jms/with-default-and-external/src/test/resources/broker.xml
@@ -6,10 +6,10 @@
         <large-messages-directory>./target/artemis/default/large-messages</large-messages-directory>
 
         <connectors>
-            <connector name="activemq">tcp://localhost:61616</connector>
+            <connector name="activemq">tcp://localhost:0</connector>
         </connectors>
         <acceptors>
-            <acceptor name="activemq">tcp://localhost:61616</acceptor>
+            <acceptor name="activemq">tcp://localhost:0</acceptor>
         </acceptors>
 
         <max-disk-usage>-1</max-disk-usage>

--- a/integration-tests/jms/with-default-change-url/src/main/resources/application.properties
+++ b/integration-tests/jms/with-default-change-url/src/main/resources/application.properties
@@ -5,4 +5,8 @@ quarkus.artemis."named-1".url=tcp://dummy-1:23456
 quarkus.artemis."named-1".devservices.enabled=false
 quarkus.artemis."named-1".xa-enabled=true
 quarkus.artemis."named-2".enabled=false
+
+quarkus.http.test-port=0
+
 quarkus.log.category."org.apache.activemq.audit".level=WARN
+quarkus.log.category."org.apache.activemq.artemis.core.server".level=WARN

--- a/integration-tests/jms/with-default-change-url/src/test/resources/broker-named-1.xml
+++ b/integration-tests/jms/with-default-change-url/src/test/resources/broker-named-1.xml
@@ -6,10 +6,10 @@
         <large-messages-directory>./target/artemis/named-1/large-messages</large-messages-directory>
 
         <connectors>
-            <connector name="activemq">tcp://localhost:61617</connector>
+            <connector name="activemq">tcp://localhost:0</connector>
         </connectors>
         <acceptors>
-            <acceptor name="activemq">tcp://localhost:61617</acceptor>
+            <acceptor name="activemq">tcp://localhost:0</acceptor>
         </acceptors>
 
         <max-disk-usage>-1</max-disk-usage>

--- a/integration-tests/jms/with-default-change-url/src/test/resources/broker.xml
+++ b/integration-tests/jms/with-default-change-url/src/test/resources/broker.xml
@@ -6,10 +6,10 @@
         <large-messages-directory>./target/artemis/default/large-messages</large-messages-directory>
 
         <connectors>
-            <connector name="activemq">tcp://localhost:61616</connector>
+            <connector name="activemq">tcp://localhost:0</connector>
         </connectors>
         <acceptors>
-            <acceptor name="activemq">tcp://localhost:61616</acceptor>
+            <acceptor name="activemq">tcp://localhost:0</acceptor>
         </acceptors>
 
         <max-disk-usage>-1</max-disk-usage>

--- a/integration-tests/jms/with-default/src/main/resources/application.properties
+++ b/integration-tests/jms/with-default/src/main/resources/application.properties
@@ -4,4 +4,8 @@ quarkus.artemis.xa-enabled=true
 quarkus.artemis."named-1".devservices.enabled=false
 quarkus.artemis."named-1".xa-enabled=true
 quarkus.artemis."named-2".enabled=false
+
+quarkus.http.test-port=0
+
 quarkus.log.category."org.apache.activemq.audit".level=WARN
+quarkus.log.category."org.apache.activemq.artemis.core.server".level=WARN

--- a/integration-tests/jms/with-default/src/test/resources/broker-named-1.xml
+++ b/integration-tests/jms/with-default/src/test/resources/broker-named-1.xml
@@ -6,10 +6,10 @@
         <large-messages-directory>./target/artemis/named-1/large-messages</large-messages-directory>
 
         <connectors>
-            <connector name="activemq">tcp://localhost:61617</connector>
+            <connector name="activemq">tcp://localhost:0</connector>
         </connectors>
         <acceptors>
-            <acceptor name="activemq">tcp://localhost:61617</acceptor>
+            <acceptor name="activemq">tcp://localhost:0</acceptor>
         </acceptors>
 
         <max-disk-usage>-1</max-disk-usage>

--- a/integration-tests/jms/with-default/src/test/resources/broker.xml
+++ b/integration-tests/jms/with-default/src/test/resources/broker.xml
@@ -6,10 +6,10 @@
         <large-messages-directory>./target/artemis/default/large-messages</large-messages-directory>
 
         <connectors>
-            <connector name="activemq">tcp://localhost:61616</connector>
+            <connector name="activemq">tcp://localhost:0</connector>
         </connectors>
         <acceptors>
-            <acceptor name="activemq">tcp://localhost:61616</acceptor>
+            <acceptor name="activemq">tcp://localhost:0</acceptor>
         </acceptors>
 
         <max-disk-usage>-1</max-disk-usage>

--- a/integration-tests/jms/with-external/src/main/resources/application.properties
+++ b/integration-tests/jms/with-external/src/main/resources/application.properties
@@ -1,1 +1,4 @@
+quarkus.http.test-port=0
+
 quarkus.log.category."org.apache.activemq.audit".level=WARN
+quarkus.log.category."org.apache.activemq.artemis.core.server".level=WARN

--- a/integration-tests/jms/with-external/src/test/resources/broker-externally-defined.xml
+++ b/integration-tests/jms/with-external/src/test/resources/broker-externally-defined.xml
@@ -6,10 +6,10 @@
         <large-messages-directory>./target/artemis/externally-defined/large-messages</large-messages-directory>
 
         <connectors>
-            <connector name="activemq">tcp://localhost:61618</connector>
+            <connector name="activemq">tcp://localhost:0</connector>
         </connectors>
         <acceptors>
-            <acceptor name="activemq">tcp://localhost:61618</acceptor>
+            <acceptor name="activemq">tcp://localhost:0</acceptor>
         </acceptors>
 
         <max-disk-usage>-1</max-disk-usage>

--- a/integration-tests/jms/with-external/src/test/resources/broker-named-1.xml
+++ b/integration-tests/jms/with-external/src/test/resources/broker-named-1.xml
@@ -6,10 +6,10 @@
         <large-messages-directory>./target/artemis/named-1/large-messages</large-messages-directory>
 
         <connectors>
-            <connector name="activemq">tcp://localhost:61617</connector>
+            <connector name="activemq">tcp://localhost:0</connector>
         </connectors>
         <acceptors>
-            <acceptor name="activemq">tcp://localhost:61617</acceptor>
+            <acceptor name="activemq">tcp://localhost:0</acceptor>
         </acceptors>
 
         <max-disk-usage>-1</max-disk-usage>

--- a/integration-tests/jms/with-external/src/test/resources/broker.xml
+++ b/integration-tests/jms/with-external/src/test/resources/broker.xml
@@ -6,10 +6,10 @@
         <large-messages-directory>./target/artemis/default/large-messages</large-messages-directory>
 
         <connectors>
-            <connector name="activemq">tcp://localhost:61616</connector>
+            <connector name="activemq">tcp://localhost:0</connector>
         </connectors>
         <acceptors>
-            <acceptor name="activemq">tcp://localhost:61616</acceptor>
+            <acceptor name="activemq">tcp://localhost:0</acceptor>
         </acceptors>
 
         <max-disk-usage>-1</max-disk-usage>

--- a/integration-tests/jms/without-default/src/main/resources/application.properties
+++ b/integration-tests/jms/without-default/src/main/resources/application.properties
@@ -1,4 +1,8 @@
 quarkus.artemis."named-1".devservices.enabled=false
 quarkus.artemis."named-1".xa-enabled=true
 quarkus.artemis."named-2".enabled=false
+
+quarkus.http.test-port=0
+
 quarkus.log.category."org.apache.activemq.audit".level=WARN
+quarkus.log.category."org.apache.activemq.artemis.core.server".level=WARN

--- a/integration-tests/jms/without-default/src/test/resources/broker-named-1.xml
+++ b/integration-tests/jms/without-default/src/test/resources/broker-named-1.xml
@@ -6,10 +6,10 @@
         <large-messages-directory>./target/artemis/named-1/large-messages</large-messages-directory>
 
         <connectors>
-            <connector name="activemq">tcp://localhost:61617</connector>
+            <connector name="activemq">tcp://localhost:0</connector>
         </connectors>
         <acceptors>
-            <acceptor name="activemq">tcp://localhost:61617</acceptor>
+            <acceptor name="activemq">tcp://localhost:0</acceptor>
         </acceptors>
 
         <max-disk-usage>-1</max-disk-usage>

--- a/integration-tests/ra/src/main/resources/application.properties
+++ b/integration-tests/ra/src/main/resources/application.properties
@@ -1,3 +1,5 @@
+quarkus.http.test-port=0
+
 # JCA Configs
 quarkus.ironjacamar.ra.kind=artemis
 quarkus.ironjacamar.ra.config.connection-parameters=host=localhost;port=61616;protocols=AMQP
@@ -23,3 +25,4 @@ quarkus.ironjacamar.activation-spec.sales.config.rebalance-connections=true
 
 # LOG Configs
 quarkus.log.category."org.apache.activemq.audit".level=WARN
+quarkus.log.category."org.apache.activemq.artemis.core.server".level=WARN


### PR DESCRIPTION
For this, we need to randomize all ports used. In particular, we need to use random ports for all embedded jms brokers (the container brokers are already randomized) and random ports for the http server.

For quarkus-artemis-ra, we do not (yet) have a way to use random ports for the brokers in tests. Therefore, we stay on port 61616 for the broker. Since this is the only broker with a fixed port, collisions with other tests are highly unlikely.

While at it, reduce logging from the embedded artemis server in test execution.