### PR TITLE
#591: instead of only creating a connection in the health check, also create a session from the already created connection.

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/artemis/core/runtime/health/ServerLocatorHealthCheck.java
+++ b/core/runtime/src/main/java/io/quarkus/artemis/core/runtime/health/ServerLocatorHealthCheck.java
@@ -9,6 +9,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Any;
 import jakarta.enterprise.inject.Instance;
 
+import org.apache.activemq.artemis.api.core.client.ClientSession;
 import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
 import org.apache.activemq.artemis.api.core.client.ServerLocator;
 import org.eclipse.microprofile.health.HealthCheck;
@@ -48,7 +49,8 @@ public class ServerLocatorHealthCheck implements HealthCheck {
         HealthCheckResponseBuilder builder = HealthCheckResponse.named("Artemis Core health check").up();
         for (String name : serverLocatorNames) {
             Annotation identifier = ArtemisUtil.toIdentifier(name);
-            try (ClientSessionFactory ignored = serverLocators.select(identifier).get().createSessionFactory()) {
+            try (ClientSessionFactory clientSessionFactory = serverLocators.select(identifier).get().createSessionFactory();
+                    ClientSession ignored = clientSessionFactory.createSession()) {
                 builder.withData(name, "UP");
             } catch (Exception e) {
                 ArtemisUtil.handleFailedHealthCheck(builder, "server locator", name, LOGGER, runtimeConfigs.healthFailLog(),

--- a/jms/runtime/src/main/java/io/quarkus/artemis/jms/runtime/health/ConnectionFactoryHealthCheck.java
+++ b/jms/runtime/src/main/java/io/quarkus/artemis/jms/runtime/health/ConnectionFactoryHealthCheck.java
@@ -10,6 +10,7 @@ import jakarta.enterprise.inject.Any;
 import jakarta.enterprise.inject.Instance;
 import jakarta.jms.Connection;
 import jakarta.jms.ConnectionFactory;
+import jakarta.jms.Session;
 
 import org.eclipse.microprofile.health.HealthCheck;
 import org.eclipse.microprofile.health.HealthCheckResponse;
@@ -49,7 +50,8 @@ public class ConnectionFactoryHealthCheck implements HealthCheck {
         HealthCheckResponseBuilder builder = HealthCheckResponse.named("Artemis JMS health check").up();
         for (String name : connectionFactoryNames) {
             Annotation identifier = ArtemisUtil.toIdentifier(name);
-            try (Connection ignored = connectionFactories.select(identifier).get().createConnection()) {
+            try (Connection connection = connectionFactories.select(identifier).get().createConnection();
+                    Session ignored = connection.createSession()) {
                 builder.withData(name, "UP");
             } catch (Exception e) {
                 ArtemisUtil.handleFailedHealthCheck(builder, "connection factory", name, LOGGER, runtimeConfigs.healthFailLog(),

--- a/ra/runtime/src/main/java/io/quarkus/artemis/jms/ra/runtime/ConnectionFactoryHealthCheck.java
+++ b/ra/runtime/src/main/java/io/quarkus/artemis/jms/ra/runtime/ConnectionFactoryHealthCheck.java
@@ -8,6 +8,7 @@ import jakarta.enterprise.inject.Any;
 import jakarta.enterprise.inject.Instance;
 import jakarta.jms.Connection;
 import jakarta.jms.ConnectionFactory;
+import jakarta.jms.Session;
 
 import org.eclipse.microprofile.health.HealthCheck;
 import org.eclipse.microprofile.health.HealthCheckResponse;
@@ -42,7 +43,8 @@ public class ConnectionFactoryHealthCheck implements HealthCheck {
         HealthCheckResponseBuilder builder = HealthCheckResponse.named("Artemis JMS Resource Adaptor health check").up();
         for (String name : connectionFactoryNames) {
             Annotation identifier = ArtemisUtil.toIdentifier(name);
-            try (Connection ignored = connectionFactories.select(identifier).get().createConnection()) {
+            try (Connection connection = connectionFactories.select(identifier).get().createConnection();
+                    Session ignored = connection.createSession()) {
                 builder.withData(name, "UP");
             } catch (Exception e) {
                 ArtemisUtil.handleFailedHealthCheck(builder, "connection factory", name, LOGGER, runtimeConfigs.healthFailLog(),


### PR DESCRIPTION
This seems to trigger an exception in quarkus-Artemis ra when all hosts are down.

Resolves #591 