### PR TITLE
Added all ServiceLocator and ConnectionFactory settings as configs

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/artemis/core/runtime/ArtemisCoreRecorder.java
+++ b/core/runtime/src/main/java/io/quarkus/artemis/core/runtime/ArtemisCoreRecorder.java
@@ -23,14 +23,65 @@ public class ArtemisCoreRecorder {
         ArtemisRuntimeConfig runtimeConfig = runtimeConfigs.getValue().configs().get(name);
         ArtemisBuildTimeConfig buildTimeConfig = buildTimeConfigs.configs().get(name);
         ArtemisUtil.validateIntegrity(name, runtimeConfig, buildTimeConfig);
-        ServerLocator serverLocator = Objects.requireNonNull(getServerLocator(runtimeConfig.getUrl()));
+        ServerLocator serverLocator = Objects.requireNonNull(getServerLocator(runtimeConfig));
         return () -> serverLocator;
     }
 
-    protected static ServerLocator getServerLocator(String url) {
-        if (url != null) {
+    protected static ServerLocator getServerLocator(ArtemisRuntimeConfig runtimeConfig) {
+        if (runtimeConfig.url().isPresent()) {
             try {
-                return ActiveMQClient.createServerLocator(url);
+                ServerLocator locator = ActiveMQClient.createServerLocator(runtimeConfig.url().get());
+
+                // --- Flow Control ---
+                runtimeConfig.consumerWindowSize().ifPresent(locator::setConsumerWindowSize);
+                runtimeConfig.consumerMaxRate().ifPresent(locator::setConsumerMaxRate);
+                runtimeConfig.producerWindowSize().ifPresent(locator::setProducerWindowSize);
+                runtimeConfig.producerMaxRate().ifPresent(locator::setProducerMaxRate);
+                runtimeConfig.confirmationWindowSize().ifPresent(locator::setConfirmationWindowSize);
+                runtimeConfig.minLargeMessageSize().ifPresent(locator::setMinLargeMessageSize);
+                runtimeConfig.compressLargeMessage().ifPresent(locator::setCompressLargeMessage);
+                runtimeConfig.compressionLevel().ifPresent(locator::setCompressionLevel);
+                runtimeConfig.cacheLargeMessagesClient().ifPresent(locator::setCacheLargeMessagesClient);
+
+                // --- Connectivity & Timeouts ---
+                runtimeConfig.clientFailureCheckPeriod().ifPresent(locator::setClientFailureCheckPeriod);
+                runtimeConfig.connectionTtl().ifPresent(locator::setConnectionTTL);
+                runtimeConfig.callTimeout().ifPresent(locator::setCallTimeout);
+                runtimeConfig.callFailoverTimeout().ifPresent(locator::setCallFailoverTimeout);
+                runtimeConfig.useGlobalPools().ifPresent(locator::setUseGlobalPools);
+                runtimeConfig.scheduledThreadPoolMaxSize().ifPresent(locator::setScheduledThreadPoolMaxSize);
+                runtimeConfig.threadPoolMaxSize().ifPresent(locator::setThreadPoolMaxSize);
+
+                // --- Retries & Failover ---
+                runtimeConfig.reconnectAttempts().ifPresent(locator::setReconnectAttempts);
+                runtimeConfig.initialConnectAttempts().ifPresent(locator::setInitialConnectAttempts);
+                runtimeConfig.failoverAttempts().ifPresent(locator::setFailoverAttempts);
+                runtimeConfig.retryInterval().ifPresent(locator::setRetryInterval);
+                runtimeConfig.retryIntervalMultiplier().ifPresent(locator::setRetryIntervalMultiplier);
+                runtimeConfig.maxRetryInterval().ifPresent(locator::setMaxRetryInterval);
+                runtimeConfig.failoverOnInitialConnection().ifPresent(locator::setFailoverOnInitialConnection);
+
+                // --- Behavior & Grouping ---
+                runtimeConfig.autoGroup().ifPresent(locator::setAutoGroup);
+                runtimeConfig.groupID().ifPresent(locator::setGroupID);
+                runtimeConfig.blockOnAcknowledge().ifPresent(locator::setBlockOnAcknowledge);
+                runtimeConfig.blockOnDurableSend().ifPresent(locator::setBlockOnDurableSend);
+                runtimeConfig.blockOnNonDurableSend().ifPresent(locator::setBlockOnNonDurableSend);
+                runtimeConfig.preAcknowledge().ifPresent(locator::setPreAcknowledge);
+                runtimeConfig.initialMessagePacketSize().ifPresent(locator::setInitialMessagePacketSize);
+
+                // --- Core Specific Section ---
+                runtimeConfig.ackBatchSize().ifPresent(locator::setAckBatchSize);
+                runtimeConfig.onMessageCloseTimeout().ifPresent(locator::setOnMessageCloseTimeout);
+                runtimeConfig.useTopologyForLoadBalancing().ifPresent(locator::setUseTopologyForLoadBalancing);
+
+                // --- Security & Policy ---
+                runtimeConfig.incomingInterceptorList().ifPresent(locator::setIncomingInterceptorList);
+                runtimeConfig.outgoingInterceptorList().ifPresent(locator::setOutgoingInterceptorList);
+                runtimeConfig.connectionLoadBalancingPolicyClassName()
+                        .ifPresent(locator::setConnectionLoadBalancingPolicyClassName);
+
+                return locator;
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }

--- a/core/runtime/src/main/java/io/quarkus/artemis/core/runtime/ArtemisRuntimeConfig.java
+++ b/core/runtime/src/main/java/io/quarkus/artemis/core/runtime/ArtemisRuntimeConfig.java
@@ -29,6 +29,250 @@ public interface ArtemisRuntimeConfig {
      */
     Optional<Boolean> healthExclude();
 
+    // --- Common Flow Control & Buffering ---
+
+    /**
+     * The window size for consumer flow control in bytes.
+     */
+    Optional<Integer> consumerWindowSize();
+
+    /**
+     * The maximum rate of messages consumed per second.
+     */
+    Optional<Integer> consumerMaxRate();
+
+    /**
+     * The window size for producer flow control in bytes.
+     */
+    Optional<Integer> producerWindowSize();
+
+    /**
+     * The maximum rate of messages produced per second.
+     */
+    Optional<Integer> producerMaxRate();
+
+    /**
+     * The window size for confirmation of sent messages in bytes.
+     */
+    Optional<Integer> confirmationWindowSize();
+
+    /**
+     * The threshold in bytes for treating a message as a large message.
+     */
+    Optional<Integer> minLargeMessageSize();
+
+    /**
+     * Whether to compress large messages sent to the server.
+     */
+    Optional<Boolean> compressLargeMessage();
+
+    /**
+     * The compression level to use (0-9).
+     */
+    Optional<Integer> compressionLevel();
+
+    /**
+     * Whether to cache large messages on the client side.
+     */
+    Optional<Boolean> cacheLargeMessagesClient();
+
+    // --- Common Connectivity & Timeouts ---
+
+    /**
+     * The frequency (ms) to check for client failure.
+     */
+    Optional<Long> clientFailureCheckPeriod();
+
+    /**
+     * How long (ms) to keep a connection alive without receiving a packet.
+     */
+    Optional<Long> connectionTtl();
+
+    /**
+     * Total time (ms) to wait for a blocking call to complete.
+     */
+    Optional<Long> callTimeout();
+
+    /**
+     * Total time (ms) to wait for a call during failover.
+     */
+    Optional<Long> callFailoverTimeout();
+
+    /**
+     * Whether to use global thread pools.
+     */
+    Optional<Boolean> useGlobalPools();
+
+    /**
+     * The maximum size of the scheduled thread pool.
+     */
+    Optional<Integer> scheduledThreadPoolMaxSize();
+
+    /**
+     * The maximum size of the general purpose thread pool.
+     */
+    Optional<Integer> threadPoolMaxSize();
+
+    // --- Common Retries & Failover ---
+
+    /**
+     * Maximum number of reconnection attempts. Use -1 for infinite.
+     */
+    Optional<Integer> reconnectAttempts();
+
+    /**
+     * Reconnection attempts for the initial connection.
+     */
+    Optional<Integer> initialConnectAttempts();
+
+    /**
+     * Maximum number of failover attempts.
+     */
+    Optional<Integer> failoverAttempts();
+
+    /**
+     * Interval (ms) between reconnection attempts.
+     */
+    Optional<Long> retryInterval();
+
+    /**
+     * Multiplier for exponential backoff on retries.
+     */
+    Optional<Double> retryIntervalMultiplier();
+
+    /**
+     * Maximum interval (ms) between retries.
+     */
+    Optional<Long> maxRetryInterval();
+
+    /**
+     * Whether to failover to backup on initial connection.
+     */
+    Optional<Boolean> failoverOnInitialConnection();
+
+    // --- Common Behavior & Grouping ---
+
+    /**
+     * Whether to automatically group messages.
+     */
+    Optional<Boolean> autoGroup();
+
+    /**
+     * The group ID to use for messages.
+     */
+    Optional<String> groupID();
+
+    /**
+     * Whether consumers block while sending acknowledgments.
+     */
+    Optional<Boolean> blockOnAcknowledge();
+
+    /**
+     * Whether producers block when sending durable messages.
+     */
+    Optional<Boolean> blockOnDurableSend();
+
+    /**
+     * Whether producers block when sending non-durable messages.
+     */
+    Optional<Boolean> blockOnNonDurableSend();
+
+    /**
+     * Whether messages are pre-acknowledged on the server.
+     */
+    Optional<Boolean> preAcknowledge();
+
+    /**
+     * The initial size of message packets in bytes.
+     */
+    Optional<Integer> initialMessagePacketSize();
+
+    // --- Core Specific Section ---
+
+    /**
+     * Core Only: The acknowledgments batch size.
+     */
+    Optional<Integer> ackBatchSize();
+
+    /**
+     * Core Only: Timeout (ms) for onMessage completion when closing consumers.
+     */
+    Optional<Integer> onMessageCloseTimeout();
+
+    /**
+     * Core Only: Whether to use cluster topology for load balancing.
+     */
+    Optional<Boolean> useTopologyForLoadBalancing();
+
+    // --- JMS Specific Section ---
+
+    /**
+     * JMS Only: The client ID for the connection.
+     */
+    Optional<String> clientID();
+
+    /**
+     * JMS Only: Whether multiple connections can share the same client ID.
+     */
+    Optional<Boolean> enableSharedClientID();
+
+    /**
+     * JMS Only: Whether to use 1.x message prefixes (jms.queue.).
+     */
+    Optional<Boolean> enable1xPrefixes();
+
+    /**
+     * JMS Only: Whether to ignore JTA for session management.
+     */
+    Optional<Boolean> ignoreJTA();
+
+    /**
+     * JMS Only: The batch size for DUPS_OK_ACKNOWLEDGE mode.
+     */
+    Optional<Integer> dupsOKBatchSize();
+
+    /**
+     * JMS Only: The batch size for transacted sessions in bytes.
+     */
+    Optional<Integer> transactionBatchSize();
+
+    /**
+     * JMS Only: Whether to cache JMS destinations on the client.
+     */
+    Optional<Boolean> cacheDestinations();
+
+    /**
+     * JMS Only: Allowed classes for ObjectMessage deserialization.
+     */
+    Optional<String> deserializationWhiteList();
+
+    /**
+     * JMS Only: Forbidden classes for ObjectMessage deserialization.
+     */
+    Optional<String> deserializationBlackList();
+
+    // --- Interceptors & Policies ---
+
+    /**
+     * Comma-separated list of incoming interceptors.
+     */
+    Optional<String> incomingInterceptorList();
+
+    /**
+     * Comma-separated list of outgoing interceptors.
+     */
+    Optional<String> outgoingInterceptorList();
+
+    /**
+     * Class name of the connection load balancing policy.
+     */
+    Optional<String> connectionLoadBalancingPolicyClassName();
+
+    /**
+     * Class name of the protocol manager factory.
+     */
+    Optional<String> protocolManagerFactoryStr();
+
     default String getUrl() {
         return url().orElse(null);
     }

--- a/docs/modules/ROOT/pages/includes/quarkus-artemis-core.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-artemis-core.adoc
@@ -229,7 +229,7 @@ endif::add-copy-button-to-config-props[]
 --
 The ActiveMQ Artemis container image to use.
 
-Defaults to `quay.io/arkmq-org/activemq-artemis-broker:artemis.2.44.0`
+Defaults to `quay.io/arkmq-org/activemq-artemis-broker:artemis.2.50.0`
 
 
 ifdef::add-copy-button-to-env-var[]
@@ -536,6 +536,1202 @@ Environment variable: `+++QUARKUS_ARTEMIS_HEALTH_EXCLUDE+++`
 endif::add-copy-button-to-env-var[]
 --
 |boolean
+|
+
+a| [[quarkus-artemis-core_quarkus-artemis-consumer-window-size]] [.property-path]##link:#quarkus-artemis-core_quarkus-artemis-consumer-window-size[`quarkus.artemis.consumer-window-size`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis.consumer-window-size+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`quarkus.artemis."configuration-name".consumer-window-size`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis."configuration-name".consumer-window-size+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+The window size for consumer flow control in bytes.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_ARTEMIS_CONSUMER_WINDOW_SIZE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_ARTEMIS_CONSUMER_WINDOW_SIZE+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a| [[quarkus-artemis-core_quarkus-artemis-consumer-max-rate]] [.property-path]##link:#quarkus-artemis-core_quarkus-artemis-consumer-max-rate[`quarkus.artemis.consumer-max-rate`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis.consumer-max-rate+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`quarkus.artemis."configuration-name".consumer-max-rate`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis."configuration-name".consumer-max-rate+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+The maximum rate of messages consumed per second.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_ARTEMIS_CONSUMER_MAX_RATE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_ARTEMIS_CONSUMER_MAX_RATE+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a| [[quarkus-artemis-core_quarkus-artemis-producer-window-size]] [.property-path]##link:#quarkus-artemis-core_quarkus-artemis-producer-window-size[`quarkus.artemis.producer-window-size`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis.producer-window-size+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`quarkus.artemis."configuration-name".producer-window-size`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis."configuration-name".producer-window-size+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+The window size for producer flow control in bytes.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_ARTEMIS_PRODUCER_WINDOW_SIZE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_ARTEMIS_PRODUCER_WINDOW_SIZE+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a| [[quarkus-artemis-core_quarkus-artemis-producer-max-rate]] [.property-path]##link:#quarkus-artemis-core_quarkus-artemis-producer-max-rate[`quarkus.artemis.producer-max-rate`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis.producer-max-rate+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`quarkus.artemis."configuration-name".producer-max-rate`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis."configuration-name".producer-max-rate+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+The maximum rate of messages produced per second.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_ARTEMIS_PRODUCER_MAX_RATE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_ARTEMIS_PRODUCER_MAX_RATE+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a| [[quarkus-artemis-core_quarkus-artemis-confirmation-window-size]] [.property-path]##link:#quarkus-artemis-core_quarkus-artemis-confirmation-window-size[`quarkus.artemis.confirmation-window-size`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis.confirmation-window-size+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`quarkus.artemis."configuration-name".confirmation-window-size`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis."configuration-name".confirmation-window-size+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+The window size for confirmation of sent messages in bytes.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_ARTEMIS_CONFIRMATION_WINDOW_SIZE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_ARTEMIS_CONFIRMATION_WINDOW_SIZE+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a| [[quarkus-artemis-core_quarkus-artemis-min-large-message-size]] [.property-path]##link:#quarkus-artemis-core_quarkus-artemis-min-large-message-size[`quarkus.artemis.min-large-message-size`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis.min-large-message-size+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`quarkus.artemis."configuration-name".min-large-message-size`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis."configuration-name".min-large-message-size+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+The threshold in bytes for treating a message as a large message.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_ARTEMIS_MIN_LARGE_MESSAGE_SIZE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_ARTEMIS_MIN_LARGE_MESSAGE_SIZE+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a| [[quarkus-artemis-core_quarkus-artemis-compress-large-message]] [.property-path]##link:#quarkus-artemis-core_quarkus-artemis-compress-large-message[`quarkus.artemis.compress-large-message`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis.compress-large-message+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`quarkus.artemis."configuration-name".compress-large-message`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis."configuration-name".compress-large-message+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+Whether to compress large messages sent to the server.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_ARTEMIS_COMPRESS_LARGE_MESSAGE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_ARTEMIS_COMPRESS_LARGE_MESSAGE+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|
+
+a| [[quarkus-artemis-core_quarkus-artemis-compression-level]] [.property-path]##link:#quarkus-artemis-core_quarkus-artemis-compression-level[`quarkus.artemis.compression-level`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis.compression-level+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`quarkus.artemis."configuration-name".compression-level`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis."configuration-name".compression-level+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+The compression level to use (0-9).
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_ARTEMIS_COMPRESSION_LEVEL+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_ARTEMIS_COMPRESSION_LEVEL+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a| [[quarkus-artemis-core_quarkus-artemis-cache-large-messages-client]] [.property-path]##link:#quarkus-artemis-core_quarkus-artemis-cache-large-messages-client[`quarkus.artemis.cache-large-messages-client`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis.cache-large-messages-client+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`quarkus.artemis."configuration-name".cache-large-messages-client`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis."configuration-name".cache-large-messages-client+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+Whether to cache large messages on the client side.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_ARTEMIS_CACHE_LARGE_MESSAGES_CLIENT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_ARTEMIS_CACHE_LARGE_MESSAGES_CLIENT+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|
+
+a| [[quarkus-artemis-core_quarkus-artemis-client-failure-check-period]] [.property-path]##link:#quarkus-artemis-core_quarkus-artemis-client-failure-check-period[`quarkus.artemis.client-failure-check-period`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis.client-failure-check-period+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`quarkus.artemis."configuration-name".client-failure-check-period`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis."configuration-name".client-failure-check-period+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+The frequency (ms) to check for client failure.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_ARTEMIS_CLIENT_FAILURE_CHECK_PERIOD+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_ARTEMIS_CLIENT_FAILURE_CHECK_PERIOD+++`
+endif::add-copy-button-to-env-var[]
+--
+|long
+|
+
+a| [[quarkus-artemis-core_quarkus-artemis-connection-ttl]] [.property-path]##link:#quarkus-artemis-core_quarkus-artemis-connection-ttl[`quarkus.artemis.connection-ttl`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis.connection-ttl+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`quarkus.artemis."configuration-name".connection-ttl`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis."configuration-name".connection-ttl+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+How long (ms) to keep a connection alive without receiving a packet.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_ARTEMIS_CONNECTION_TTL+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_ARTEMIS_CONNECTION_TTL+++`
+endif::add-copy-button-to-env-var[]
+--
+|long
+|
+
+a| [[quarkus-artemis-core_quarkus-artemis-call-timeout]] [.property-path]##link:#quarkus-artemis-core_quarkus-artemis-call-timeout[`quarkus.artemis.call-timeout`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis.call-timeout+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`quarkus.artemis."configuration-name".call-timeout`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis."configuration-name".call-timeout+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+Total time (ms) to wait for a blocking call to complete.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_ARTEMIS_CALL_TIMEOUT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_ARTEMIS_CALL_TIMEOUT+++`
+endif::add-copy-button-to-env-var[]
+--
+|long
+|
+
+a| [[quarkus-artemis-core_quarkus-artemis-call-failover-timeout]] [.property-path]##link:#quarkus-artemis-core_quarkus-artemis-call-failover-timeout[`quarkus.artemis.call-failover-timeout`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis.call-failover-timeout+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`quarkus.artemis."configuration-name".call-failover-timeout`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis."configuration-name".call-failover-timeout+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+Total time (ms) to wait for a call during failover.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_ARTEMIS_CALL_FAILOVER_TIMEOUT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_ARTEMIS_CALL_FAILOVER_TIMEOUT+++`
+endif::add-copy-button-to-env-var[]
+--
+|long
+|
+
+a| [[quarkus-artemis-core_quarkus-artemis-use-global-pools]] [.property-path]##link:#quarkus-artemis-core_quarkus-artemis-use-global-pools[`quarkus.artemis.use-global-pools`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis.use-global-pools+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`quarkus.artemis."configuration-name".use-global-pools`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis."configuration-name".use-global-pools+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+Whether to use global thread pools.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_ARTEMIS_USE_GLOBAL_POOLS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_ARTEMIS_USE_GLOBAL_POOLS+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|
+
+a| [[quarkus-artemis-core_quarkus-artemis-scheduled-thread-pool-max-size]] [.property-path]##link:#quarkus-artemis-core_quarkus-artemis-scheduled-thread-pool-max-size[`quarkus.artemis.scheduled-thread-pool-max-size`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis.scheduled-thread-pool-max-size+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`quarkus.artemis."configuration-name".scheduled-thread-pool-max-size`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis."configuration-name".scheduled-thread-pool-max-size+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+The maximum size of the scheduled thread pool.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_ARTEMIS_SCHEDULED_THREAD_POOL_MAX_SIZE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_ARTEMIS_SCHEDULED_THREAD_POOL_MAX_SIZE+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a| [[quarkus-artemis-core_quarkus-artemis-thread-pool-max-size]] [.property-path]##link:#quarkus-artemis-core_quarkus-artemis-thread-pool-max-size[`quarkus.artemis.thread-pool-max-size`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis.thread-pool-max-size+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`quarkus.artemis."configuration-name".thread-pool-max-size`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis."configuration-name".thread-pool-max-size+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+The maximum size of the general purpose thread pool.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_ARTEMIS_THREAD_POOL_MAX_SIZE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_ARTEMIS_THREAD_POOL_MAX_SIZE+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a| [[quarkus-artemis-core_quarkus-artemis-reconnect-attempts]] [.property-path]##link:#quarkus-artemis-core_quarkus-artemis-reconnect-attempts[`quarkus.artemis.reconnect-attempts`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis.reconnect-attempts+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`quarkus.artemis."configuration-name".reconnect-attempts`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis."configuration-name".reconnect-attempts+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+Maximum number of reconnection attempts. Use -1 for infinite.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_ARTEMIS_RECONNECT_ATTEMPTS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_ARTEMIS_RECONNECT_ATTEMPTS+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a| [[quarkus-artemis-core_quarkus-artemis-initial-connect-attempts]] [.property-path]##link:#quarkus-artemis-core_quarkus-artemis-initial-connect-attempts[`quarkus.artemis.initial-connect-attempts`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis.initial-connect-attempts+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`quarkus.artemis."configuration-name".initial-connect-attempts`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis."configuration-name".initial-connect-attempts+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+Reconnection attempts for the initial connection.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_ARTEMIS_INITIAL_CONNECT_ATTEMPTS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_ARTEMIS_INITIAL_CONNECT_ATTEMPTS+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a| [[quarkus-artemis-core_quarkus-artemis-failover-attempts]] [.property-path]##link:#quarkus-artemis-core_quarkus-artemis-failover-attempts[`quarkus.artemis.failover-attempts`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis.failover-attempts+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`quarkus.artemis."configuration-name".failover-attempts`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis."configuration-name".failover-attempts+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+Maximum number of failover attempts.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_ARTEMIS_FAILOVER_ATTEMPTS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_ARTEMIS_FAILOVER_ATTEMPTS+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a| [[quarkus-artemis-core_quarkus-artemis-retry-interval]] [.property-path]##link:#quarkus-artemis-core_quarkus-artemis-retry-interval[`quarkus.artemis.retry-interval`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis.retry-interval+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`quarkus.artemis."configuration-name".retry-interval`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis."configuration-name".retry-interval+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+Interval (ms) between reconnection attempts.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_ARTEMIS_RETRY_INTERVAL+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_ARTEMIS_RETRY_INTERVAL+++`
+endif::add-copy-button-to-env-var[]
+--
+|long
+|
+
+a| [[quarkus-artemis-core_quarkus-artemis-retry-interval-multiplier]] [.property-path]##link:#quarkus-artemis-core_quarkus-artemis-retry-interval-multiplier[`quarkus.artemis.retry-interval-multiplier`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis.retry-interval-multiplier+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`quarkus.artemis."configuration-name".retry-interval-multiplier`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis."configuration-name".retry-interval-multiplier+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+Multiplier for exponential backoff on retries.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_ARTEMIS_RETRY_INTERVAL_MULTIPLIER+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_ARTEMIS_RETRY_INTERVAL_MULTIPLIER+++`
+endif::add-copy-button-to-env-var[]
+--
+|double
+|
+
+a| [[quarkus-artemis-core_quarkus-artemis-max-retry-interval]] [.property-path]##link:#quarkus-artemis-core_quarkus-artemis-max-retry-interval[`quarkus.artemis.max-retry-interval`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis.max-retry-interval+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`quarkus.artemis."configuration-name".max-retry-interval`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis."configuration-name".max-retry-interval+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+Maximum interval (ms) between retries.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_ARTEMIS_MAX_RETRY_INTERVAL+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_ARTEMIS_MAX_RETRY_INTERVAL+++`
+endif::add-copy-button-to-env-var[]
+--
+|long
+|
+
+a| [[quarkus-artemis-core_quarkus-artemis-failover-on-initial-connection]] [.property-path]##link:#quarkus-artemis-core_quarkus-artemis-failover-on-initial-connection[`quarkus.artemis.failover-on-initial-connection`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis.failover-on-initial-connection+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`quarkus.artemis."configuration-name".failover-on-initial-connection`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis."configuration-name".failover-on-initial-connection+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+Whether to failover to backup on initial connection.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_ARTEMIS_FAILOVER_ON_INITIAL_CONNECTION+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_ARTEMIS_FAILOVER_ON_INITIAL_CONNECTION+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|
+
+a| [[quarkus-artemis-core_quarkus-artemis-auto-group]] [.property-path]##link:#quarkus-artemis-core_quarkus-artemis-auto-group[`quarkus.artemis.auto-group`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis.auto-group+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`quarkus.artemis."configuration-name".auto-group`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis."configuration-name".auto-group+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+Whether to automatically group messages.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_ARTEMIS_AUTO_GROUP+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_ARTEMIS_AUTO_GROUP+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|
+
+a| [[quarkus-artemis-core_quarkus-artemis-group-id]] [.property-path]##link:#quarkus-artemis-core_quarkus-artemis-group-id[`quarkus.artemis.group-id`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis.group-id+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`quarkus.artemis."configuration-name".group-id`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis."configuration-name".group-id+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+The group ID to use for messages.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_ARTEMIS_GROUP_ID+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_ARTEMIS_GROUP_ID+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-artemis-core_quarkus-artemis-block-on-acknowledge]] [.property-path]##link:#quarkus-artemis-core_quarkus-artemis-block-on-acknowledge[`quarkus.artemis.block-on-acknowledge`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis.block-on-acknowledge+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`quarkus.artemis."configuration-name".block-on-acknowledge`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis."configuration-name".block-on-acknowledge+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+Whether consumers block while sending acknowledgments.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_ARTEMIS_BLOCK_ON_ACKNOWLEDGE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_ARTEMIS_BLOCK_ON_ACKNOWLEDGE+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|
+
+a| [[quarkus-artemis-core_quarkus-artemis-block-on-durable-send]] [.property-path]##link:#quarkus-artemis-core_quarkus-artemis-block-on-durable-send[`quarkus.artemis.block-on-durable-send`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis.block-on-durable-send+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`quarkus.artemis."configuration-name".block-on-durable-send`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis."configuration-name".block-on-durable-send+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+Whether producers block when sending durable messages.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_ARTEMIS_BLOCK_ON_DURABLE_SEND+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_ARTEMIS_BLOCK_ON_DURABLE_SEND+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|
+
+a| [[quarkus-artemis-core_quarkus-artemis-block-on-non-durable-send]] [.property-path]##link:#quarkus-artemis-core_quarkus-artemis-block-on-non-durable-send[`quarkus.artemis.block-on-non-durable-send`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis.block-on-non-durable-send+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`quarkus.artemis."configuration-name".block-on-non-durable-send`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis."configuration-name".block-on-non-durable-send+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+Whether producers block when sending non-durable messages.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_ARTEMIS_BLOCK_ON_NON_DURABLE_SEND+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_ARTEMIS_BLOCK_ON_NON_DURABLE_SEND+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|
+
+a| [[quarkus-artemis-core_quarkus-artemis-pre-acknowledge]] [.property-path]##link:#quarkus-artemis-core_quarkus-artemis-pre-acknowledge[`quarkus.artemis.pre-acknowledge`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis.pre-acknowledge+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`quarkus.artemis."configuration-name".pre-acknowledge`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis."configuration-name".pre-acknowledge+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+Whether messages are pre-acknowledged on the server.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_ARTEMIS_PRE_ACKNOWLEDGE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_ARTEMIS_PRE_ACKNOWLEDGE+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|
+
+a| [[quarkus-artemis-core_quarkus-artemis-initial-message-packet-size]] [.property-path]##link:#quarkus-artemis-core_quarkus-artemis-initial-message-packet-size[`quarkus.artemis.initial-message-packet-size`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis.initial-message-packet-size+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`quarkus.artemis."configuration-name".initial-message-packet-size`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis."configuration-name".initial-message-packet-size+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+The initial size of message packets in bytes.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_ARTEMIS_INITIAL_MESSAGE_PACKET_SIZE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_ARTEMIS_INITIAL_MESSAGE_PACKET_SIZE+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a| [[quarkus-artemis-core_quarkus-artemis-ack-batch-size]] [.property-path]##link:#quarkus-artemis-core_quarkus-artemis-ack-batch-size[`quarkus.artemis.ack-batch-size`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis.ack-batch-size+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`quarkus.artemis."configuration-name".ack-batch-size`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis."configuration-name".ack-batch-size+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+Core Only: The acknowledgments batch size.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_ARTEMIS_ACK_BATCH_SIZE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_ARTEMIS_ACK_BATCH_SIZE+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a| [[quarkus-artemis-core_quarkus-artemis-on-message-close-timeout]] [.property-path]##link:#quarkus-artemis-core_quarkus-artemis-on-message-close-timeout[`quarkus.artemis.on-message-close-timeout`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis.on-message-close-timeout+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`quarkus.artemis."configuration-name".on-message-close-timeout`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis."configuration-name".on-message-close-timeout+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+Core Only: Timeout (ms) for onMessage completion when closing consumers.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_ARTEMIS_ON_MESSAGE_CLOSE_TIMEOUT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_ARTEMIS_ON_MESSAGE_CLOSE_TIMEOUT+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a| [[quarkus-artemis-core_quarkus-artemis-use-topology-for-load-balancing]] [.property-path]##link:#quarkus-artemis-core_quarkus-artemis-use-topology-for-load-balancing[`quarkus.artemis.use-topology-for-load-balancing`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis.use-topology-for-load-balancing+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`quarkus.artemis."configuration-name".use-topology-for-load-balancing`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis."configuration-name".use-topology-for-load-balancing+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+Core Only: Whether to use cluster topology for load balancing.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_ARTEMIS_USE_TOPOLOGY_FOR_LOAD_BALANCING+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_ARTEMIS_USE_TOPOLOGY_FOR_LOAD_BALANCING+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|
+
+a| [[quarkus-artemis-core_quarkus-artemis-client-id]] [.property-path]##link:#quarkus-artemis-core_quarkus-artemis-client-id[`quarkus.artemis.client-id`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis.client-id+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`quarkus.artemis."configuration-name".client-id`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis."configuration-name".client-id+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+JMS Only: The client ID for the connection.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_ARTEMIS_CLIENT_ID+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_ARTEMIS_CLIENT_ID+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-artemis-core_quarkus-artemis-enable-shared-client-id]] [.property-path]##link:#quarkus-artemis-core_quarkus-artemis-enable-shared-client-id[`quarkus.artemis.enable-shared-client-id`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis.enable-shared-client-id+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`quarkus.artemis."configuration-name".enable-shared-client-id`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis."configuration-name".enable-shared-client-id+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+JMS Only: Whether multiple connections can share the same client ID.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_ARTEMIS_ENABLE_SHARED_CLIENT_ID+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_ARTEMIS_ENABLE_SHARED_CLIENT_ID+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|
+
+a| [[quarkus-artemis-core_quarkus-artemis-enable1x-prefixes]] [.property-path]##link:#quarkus-artemis-core_quarkus-artemis-enable1x-prefixes[`quarkus.artemis.enable1x-prefixes`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis.enable1x-prefixes+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`quarkus.artemis."configuration-name".enable1x-prefixes`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis."configuration-name".enable1x-prefixes+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+JMS Only: Whether to use 1.x message prefixes (jms.queue.).
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_ARTEMIS_ENABLE1X_PREFIXES+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_ARTEMIS_ENABLE1X_PREFIXES+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|
+
+a| [[quarkus-artemis-core_quarkus-artemis-ignore-jta]] [.property-path]##link:#quarkus-artemis-core_quarkus-artemis-ignore-jta[`quarkus.artemis.ignore-jta`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis.ignore-jta+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`quarkus.artemis."configuration-name".ignore-jta`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis."configuration-name".ignore-jta+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+JMS Only: Whether to ignore JTA for session management.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_ARTEMIS_IGNORE_JTA+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_ARTEMIS_IGNORE_JTA+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|
+
+a| [[quarkus-artemis-core_quarkus-artemis-dups-ok-batch-size]] [.property-path]##link:#quarkus-artemis-core_quarkus-artemis-dups-ok-batch-size[`quarkus.artemis.dups-ok-batch-size`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis.dups-ok-batch-size+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`quarkus.artemis."configuration-name".dups-ok-batch-size`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis."configuration-name".dups-ok-batch-size+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+JMS Only: The batch size for DUPS_OK_ACKNOWLEDGE mode.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_ARTEMIS_DUPS_OK_BATCH_SIZE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_ARTEMIS_DUPS_OK_BATCH_SIZE+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a| [[quarkus-artemis-core_quarkus-artemis-transaction-batch-size]] [.property-path]##link:#quarkus-artemis-core_quarkus-artemis-transaction-batch-size[`quarkus.artemis.transaction-batch-size`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis.transaction-batch-size+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`quarkus.artemis."configuration-name".transaction-batch-size`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis."configuration-name".transaction-batch-size+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+JMS Only: The batch size for transacted sessions in bytes.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_ARTEMIS_TRANSACTION_BATCH_SIZE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_ARTEMIS_TRANSACTION_BATCH_SIZE+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a| [[quarkus-artemis-core_quarkus-artemis-cache-destinations]] [.property-path]##link:#quarkus-artemis-core_quarkus-artemis-cache-destinations[`quarkus.artemis.cache-destinations`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis.cache-destinations+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`quarkus.artemis."configuration-name".cache-destinations`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis."configuration-name".cache-destinations+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+JMS Only: Whether to cache JMS destinations on the client.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_ARTEMIS_CACHE_DESTINATIONS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_ARTEMIS_CACHE_DESTINATIONS+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|
+
+a| [[quarkus-artemis-core_quarkus-artemis-deserialization-white-list]] [.property-path]##link:#quarkus-artemis-core_quarkus-artemis-deserialization-white-list[`quarkus.artemis.deserialization-white-list`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis.deserialization-white-list+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`quarkus.artemis."configuration-name".deserialization-white-list`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis."configuration-name".deserialization-white-list+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+JMS Only: Allowed classes for ObjectMessage deserialization.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_ARTEMIS_DESERIALIZATION_WHITE_LIST+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_ARTEMIS_DESERIALIZATION_WHITE_LIST+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-artemis-core_quarkus-artemis-deserialization-black-list]] [.property-path]##link:#quarkus-artemis-core_quarkus-artemis-deserialization-black-list[`quarkus.artemis.deserialization-black-list`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis.deserialization-black-list+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`quarkus.artemis."configuration-name".deserialization-black-list`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis."configuration-name".deserialization-black-list+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+JMS Only: Forbidden classes for ObjectMessage deserialization.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_ARTEMIS_DESERIALIZATION_BLACK_LIST+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_ARTEMIS_DESERIALIZATION_BLACK_LIST+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-artemis-core_quarkus-artemis-incoming-interceptor-list]] [.property-path]##link:#quarkus-artemis-core_quarkus-artemis-incoming-interceptor-list[`quarkus.artemis.incoming-interceptor-list`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis.incoming-interceptor-list+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`quarkus.artemis."configuration-name".incoming-interceptor-list`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis."configuration-name".incoming-interceptor-list+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+Comma-separated list of incoming interceptors.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_ARTEMIS_INCOMING_INTERCEPTOR_LIST+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_ARTEMIS_INCOMING_INTERCEPTOR_LIST+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-artemis-core_quarkus-artemis-outgoing-interceptor-list]] [.property-path]##link:#quarkus-artemis-core_quarkus-artemis-outgoing-interceptor-list[`quarkus.artemis.outgoing-interceptor-list`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis.outgoing-interceptor-list+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`quarkus.artemis."configuration-name".outgoing-interceptor-list`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis."configuration-name".outgoing-interceptor-list+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+Comma-separated list of outgoing interceptors.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_ARTEMIS_OUTGOING_INTERCEPTOR_LIST+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_ARTEMIS_OUTGOING_INTERCEPTOR_LIST+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-artemis-core_quarkus-artemis-connection-load-balancing-policy-class-name]] [.property-path]##link:#quarkus-artemis-core_quarkus-artemis-connection-load-balancing-policy-class-name[`quarkus.artemis.connection-load-balancing-policy-class-name`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis.connection-load-balancing-policy-class-name+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`quarkus.artemis."configuration-name".connection-load-balancing-policy-class-name`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis."configuration-name".connection-load-balancing-policy-class-name+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+Class name of the connection load balancing policy.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_ARTEMIS_CONNECTION_LOAD_BALANCING_POLICY_CLASS_NAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_ARTEMIS_CONNECTION_LOAD_BALANCING_POLICY_CLASS_NAME+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-artemis-core_quarkus-artemis-protocol-manager-factory-str]] [.property-path]##link:#quarkus-artemis-core_quarkus-artemis-protocol-manager-factory-str[`quarkus.artemis.protocol-manager-factory-str`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis.protocol-manager-factory-str+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`quarkus.artemis."configuration-name".protocol-manager-factory-str`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis."configuration-name".protocol-manager-factory-str+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+Class name of the protocol manager factory.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_ARTEMIS_PROTOCOL_MANAGER_FACTORY_STR+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_ARTEMIS_PROTOCOL_MANAGER_FACTORY_STR+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
 |
 
 

--- a/docs/modules/ROOT/pages/includes/quarkus-artemis-core_quarkus.artemis.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-artemis-core_quarkus.artemis.adoc
@@ -229,7 +229,7 @@ endif::add-copy-button-to-config-props[]
 --
 The ActiveMQ Artemis container image to use.
 
-Defaults to `quay.io/arkmq-org/activemq-artemis-broker:artemis.2.44.0`
+Defaults to `quay.io/arkmq-org/activemq-artemis-broker:artemis.2.50.0`
 
 
 ifdef::add-copy-button-to-env-var[]
@@ -536,6 +536,1202 @@ Environment variable: `+++QUARKUS_ARTEMIS_HEALTH_EXCLUDE+++`
 endif::add-copy-button-to-env-var[]
 --
 |boolean
+|
+
+a| [[quarkus-artemis-core_quarkus-artemis-consumer-window-size]] [.property-path]##link:#quarkus-artemis-core_quarkus-artemis-consumer-window-size[`quarkus.artemis.consumer-window-size`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis.consumer-window-size+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`quarkus.artemis."configuration-name".consumer-window-size`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis."configuration-name".consumer-window-size+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+The window size for consumer flow control in bytes.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_ARTEMIS_CONSUMER_WINDOW_SIZE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_ARTEMIS_CONSUMER_WINDOW_SIZE+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a| [[quarkus-artemis-core_quarkus-artemis-consumer-max-rate]] [.property-path]##link:#quarkus-artemis-core_quarkus-artemis-consumer-max-rate[`quarkus.artemis.consumer-max-rate`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis.consumer-max-rate+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`quarkus.artemis."configuration-name".consumer-max-rate`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis."configuration-name".consumer-max-rate+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+The maximum rate of messages consumed per second.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_ARTEMIS_CONSUMER_MAX_RATE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_ARTEMIS_CONSUMER_MAX_RATE+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a| [[quarkus-artemis-core_quarkus-artemis-producer-window-size]] [.property-path]##link:#quarkus-artemis-core_quarkus-artemis-producer-window-size[`quarkus.artemis.producer-window-size`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis.producer-window-size+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`quarkus.artemis."configuration-name".producer-window-size`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis."configuration-name".producer-window-size+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+The window size for producer flow control in bytes.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_ARTEMIS_PRODUCER_WINDOW_SIZE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_ARTEMIS_PRODUCER_WINDOW_SIZE+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a| [[quarkus-artemis-core_quarkus-artemis-producer-max-rate]] [.property-path]##link:#quarkus-artemis-core_quarkus-artemis-producer-max-rate[`quarkus.artemis.producer-max-rate`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis.producer-max-rate+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`quarkus.artemis."configuration-name".producer-max-rate`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis."configuration-name".producer-max-rate+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+The maximum rate of messages produced per second.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_ARTEMIS_PRODUCER_MAX_RATE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_ARTEMIS_PRODUCER_MAX_RATE+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a| [[quarkus-artemis-core_quarkus-artemis-confirmation-window-size]] [.property-path]##link:#quarkus-artemis-core_quarkus-artemis-confirmation-window-size[`quarkus.artemis.confirmation-window-size`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis.confirmation-window-size+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`quarkus.artemis."configuration-name".confirmation-window-size`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis."configuration-name".confirmation-window-size+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+The window size for confirmation of sent messages in bytes.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_ARTEMIS_CONFIRMATION_WINDOW_SIZE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_ARTEMIS_CONFIRMATION_WINDOW_SIZE+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a| [[quarkus-artemis-core_quarkus-artemis-min-large-message-size]] [.property-path]##link:#quarkus-artemis-core_quarkus-artemis-min-large-message-size[`quarkus.artemis.min-large-message-size`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis.min-large-message-size+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`quarkus.artemis."configuration-name".min-large-message-size`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis."configuration-name".min-large-message-size+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+The threshold in bytes for treating a message as a large message.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_ARTEMIS_MIN_LARGE_MESSAGE_SIZE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_ARTEMIS_MIN_LARGE_MESSAGE_SIZE+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a| [[quarkus-artemis-core_quarkus-artemis-compress-large-message]] [.property-path]##link:#quarkus-artemis-core_quarkus-artemis-compress-large-message[`quarkus.artemis.compress-large-message`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis.compress-large-message+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`quarkus.artemis."configuration-name".compress-large-message`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis."configuration-name".compress-large-message+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+Whether to compress large messages sent to the server.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_ARTEMIS_COMPRESS_LARGE_MESSAGE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_ARTEMIS_COMPRESS_LARGE_MESSAGE+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|
+
+a| [[quarkus-artemis-core_quarkus-artemis-compression-level]] [.property-path]##link:#quarkus-artemis-core_quarkus-artemis-compression-level[`quarkus.artemis.compression-level`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis.compression-level+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`quarkus.artemis."configuration-name".compression-level`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis."configuration-name".compression-level+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+The compression level to use (0-9).
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_ARTEMIS_COMPRESSION_LEVEL+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_ARTEMIS_COMPRESSION_LEVEL+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a| [[quarkus-artemis-core_quarkus-artemis-cache-large-messages-client]] [.property-path]##link:#quarkus-artemis-core_quarkus-artemis-cache-large-messages-client[`quarkus.artemis.cache-large-messages-client`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis.cache-large-messages-client+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`quarkus.artemis."configuration-name".cache-large-messages-client`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis."configuration-name".cache-large-messages-client+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+Whether to cache large messages on the client side.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_ARTEMIS_CACHE_LARGE_MESSAGES_CLIENT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_ARTEMIS_CACHE_LARGE_MESSAGES_CLIENT+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|
+
+a| [[quarkus-artemis-core_quarkus-artemis-client-failure-check-period]] [.property-path]##link:#quarkus-artemis-core_quarkus-artemis-client-failure-check-period[`quarkus.artemis.client-failure-check-period`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis.client-failure-check-period+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`quarkus.artemis."configuration-name".client-failure-check-period`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis."configuration-name".client-failure-check-period+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+The frequency (ms) to check for client failure.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_ARTEMIS_CLIENT_FAILURE_CHECK_PERIOD+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_ARTEMIS_CLIENT_FAILURE_CHECK_PERIOD+++`
+endif::add-copy-button-to-env-var[]
+--
+|long
+|
+
+a| [[quarkus-artemis-core_quarkus-artemis-connection-ttl]] [.property-path]##link:#quarkus-artemis-core_quarkus-artemis-connection-ttl[`quarkus.artemis.connection-ttl`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis.connection-ttl+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`quarkus.artemis."configuration-name".connection-ttl`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis."configuration-name".connection-ttl+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+How long (ms) to keep a connection alive without receiving a packet.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_ARTEMIS_CONNECTION_TTL+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_ARTEMIS_CONNECTION_TTL+++`
+endif::add-copy-button-to-env-var[]
+--
+|long
+|
+
+a| [[quarkus-artemis-core_quarkus-artemis-call-timeout]] [.property-path]##link:#quarkus-artemis-core_quarkus-artemis-call-timeout[`quarkus.artemis.call-timeout`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis.call-timeout+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`quarkus.artemis."configuration-name".call-timeout`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis."configuration-name".call-timeout+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+Total time (ms) to wait for a blocking call to complete.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_ARTEMIS_CALL_TIMEOUT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_ARTEMIS_CALL_TIMEOUT+++`
+endif::add-copy-button-to-env-var[]
+--
+|long
+|
+
+a| [[quarkus-artemis-core_quarkus-artemis-call-failover-timeout]] [.property-path]##link:#quarkus-artemis-core_quarkus-artemis-call-failover-timeout[`quarkus.artemis.call-failover-timeout`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis.call-failover-timeout+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`quarkus.artemis."configuration-name".call-failover-timeout`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis."configuration-name".call-failover-timeout+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+Total time (ms) to wait for a call during failover.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_ARTEMIS_CALL_FAILOVER_TIMEOUT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_ARTEMIS_CALL_FAILOVER_TIMEOUT+++`
+endif::add-copy-button-to-env-var[]
+--
+|long
+|
+
+a| [[quarkus-artemis-core_quarkus-artemis-use-global-pools]] [.property-path]##link:#quarkus-artemis-core_quarkus-artemis-use-global-pools[`quarkus.artemis.use-global-pools`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis.use-global-pools+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`quarkus.artemis."configuration-name".use-global-pools`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis."configuration-name".use-global-pools+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+Whether to use global thread pools.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_ARTEMIS_USE_GLOBAL_POOLS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_ARTEMIS_USE_GLOBAL_POOLS+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|
+
+a| [[quarkus-artemis-core_quarkus-artemis-scheduled-thread-pool-max-size]] [.property-path]##link:#quarkus-artemis-core_quarkus-artemis-scheduled-thread-pool-max-size[`quarkus.artemis.scheduled-thread-pool-max-size`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis.scheduled-thread-pool-max-size+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`quarkus.artemis."configuration-name".scheduled-thread-pool-max-size`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis."configuration-name".scheduled-thread-pool-max-size+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+The maximum size of the scheduled thread pool.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_ARTEMIS_SCHEDULED_THREAD_POOL_MAX_SIZE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_ARTEMIS_SCHEDULED_THREAD_POOL_MAX_SIZE+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a| [[quarkus-artemis-core_quarkus-artemis-thread-pool-max-size]] [.property-path]##link:#quarkus-artemis-core_quarkus-artemis-thread-pool-max-size[`quarkus.artemis.thread-pool-max-size`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis.thread-pool-max-size+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`quarkus.artemis."configuration-name".thread-pool-max-size`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis."configuration-name".thread-pool-max-size+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+The maximum size of the general purpose thread pool.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_ARTEMIS_THREAD_POOL_MAX_SIZE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_ARTEMIS_THREAD_POOL_MAX_SIZE+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a| [[quarkus-artemis-core_quarkus-artemis-reconnect-attempts]] [.property-path]##link:#quarkus-artemis-core_quarkus-artemis-reconnect-attempts[`quarkus.artemis.reconnect-attempts`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis.reconnect-attempts+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`quarkus.artemis."configuration-name".reconnect-attempts`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis."configuration-name".reconnect-attempts+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+Maximum number of reconnection attempts. Use -1 for infinite.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_ARTEMIS_RECONNECT_ATTEMPTS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_ARTEMIS_RECONNECT_ATTEMPTS+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a| [[quarkus-artemis-core_quarkus-artemis-initial-connect-attempts]] [.property-path]##link:#quarkus-artemis-core_quarkus-artemis-initial-connect-attempts[`quarkus.artemis.initial-connect-attempts`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis.initial-connect-attempts+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`quarkus.artemis."configuration-name".initial-connect-attempts`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis."configuration-name".initial-connect-attempts+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+Reconnection attempts for the initial connection.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_ARTEMIS_INITIAL_CONNECT_ATTEMPTS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_ARTEMIS_INITIAL_CONNECT_ATTEMPTS+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a| [[quarkus-artemis-core_quarkus-artemis-failover-attempts]] [.property-path]##link:#quarkus-artemis-core_quarkus-artemis-failover-attempts[`quarkus.artemis.failover-attempts`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis.failover-attempts+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`quarkus.artemis."configuration-name".failover-attempts`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis."configuration-name".failover-attempts+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+Maximum number of failover attempts.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_ARTEMIS_FAILOVER_ATTEMPTS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_ARTEMIS_FAILOVER_ATTEMPTS+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a| [[quarkus-artemis-core_quarkus-artemis-retry-interval]] [.property-path]##link:#quarkus-artemis-core_quarkus-artemis-retry-interval[`quarkus.artemis.retry-interval`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis.retry-interval+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`quarkus.artemis."configuration-name".retry-interval`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis."configuration-name".retry-interval+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+Interval (ms) between reconnection attempts.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_ARTEMIS_RETRY_INTERVAL+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_ARTEMIS_RETRY_INTERVAL+++`
+endif::add-copy-button-to-env-var[]
+--
+|long
+|
+
+a| [[quarkus-artemis-core_quarkus-artemis-retry-interval-multiplier]] [.property-path]##link:#quarkus-artemis-core_quarkus-artemis-retry-interval-multiplier[`quarkus.artemis.retry-interval-multiplier`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis.retry-interval-multiplier+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`quarkus.artemis."configuration-name".retry-interval-multiplier`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis."configuration-name".retry-interval-multiplier+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+Multiplier for exponential backoff on retries.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_ARTEMIS_RETRY_INTERVAL_MULTIPLIER+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_ARTEMIS_RETRY_INTERVAL_MULTIPLIER+++`
+endif::add-copy-button-to-env-var[]
+--
+|double
+|
+
+a| [[quarkus-artemis-core_quarkus-artemis-max-retry-interval]] [.property-path]##link:#quarkus-artemis-core_quarkus-artemis-max-retry-interval[`quarkus.artemis.max-retry-interval`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis.max-retry-interval+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`quarkus.artemis."configuration-name".max-retry-interval`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis."configuration-name".max-retry-interval+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+Maximum interval (ms) between retries.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_ARTEMIS_MAX_RETRY_INTERVAL+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_ARTEMIS_MAX_RETRY_INTERVAL+++`
+endif::add-copy-button-to-env-var[]
+--
+|long
+|
+
+a| [[quarkus-artemis-core_quarkus-artemis-failover-on-initial-connection]] [.property-path]##link:#quarkus-artemis-core_quarkus-artemis-failover-on-initial-connection[`quarkus.artemis.failover-on-initial-connection`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis.failover-on-initial-connection+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`quarkus.artemis."configuration-name".failover-on-initial-connection`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis."configuration-name".failover-on-initial-connection+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+Whether to failover to backup on initial connection.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_ARTEMIS_FAILOVER_ON_INITIAL_CONNECTION+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_ARTEMIS_FAILOVER_ON_INITIAL_CONNECTION+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|
+
+a| [[quarkus-artemis-core_quarkus-artemis-auto-group]] [.property-path]##link:#quarkus-artemis-core_quarkus-artemis-auto-group[`quarkus.artemis.auto-group`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis.auto-group+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`quarkus.artemis."configuration-name".auto-group`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis."configuration-name".auto-group+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+Whether to automatically group messages.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_ARTEMIS_AUTO_GROUP+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_ARTEMIS_AUTO_GROUP+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|
+
+a| [[quarkus-artemis-core_quarkus-artemis-group-id]] [.property-path]##link:#quarkus-artemis-core_quarkus-artemis-group-id[`quarkus.artemis.group-id`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis.group-id+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`quarkus.artemis."configuration-name".group-id`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis."configuration-name".group-id+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+The group ID to use for messages.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_ARTEMIS_GROUP_ID+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_ARTEMIS_GROUP_ID+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-artemis-core_quarkus-artemis-block-on-acknowledge]] [.property-path]##link:#quarkus-artemis-core_quarkus-artemis-block-on-acknowledge[`quarkus.artemis.block-on-acknowledge`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis.block-on-acknowledge+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`quarkus.artemis."configuration-name".block-on-acknowledge`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis."configuration-name".block-on-acknowledge+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+Whether consumers block while sending acknowledgments.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_ARTEMIS_BLOCK_ON_ACKNOWLEDGE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_ARTEMIS_BLOCK_ON_ACKNOWLEDGE+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|
+
+a| [[quarkus-artemis-core_quarkus-artemis-block-on-durable-send]] [.property-path]##link:#quarkus-artemis-core_quarkus-artemis-block-on-durable-send[`quarkus.artemis.block-on-durable-send`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis.block-on-durable-send+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`quarkus.artemis."configuration-name".block-on-durable-send`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis."configuration-name".block-on-durable-send+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+Whether producers block when sending durable messages.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_ARTEMIS_BLOCK_ON_DURABLE_SEND+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_ARTEMIS_BLOCK_ON_DURABLE_SEND+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|
+
+a| [[quarkus-artemis-core_quarkus-artemis-block-on-non-durable-send]] [.property-path]##link:#quarkus-artemis-core_quarkus-artemis-block-on-non-durable-send[`quarkus.artemis.block-on-non-durable-send`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis.block-on-non-durable-send+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`quarkus.artemis."configuration-name".block-on-non-durable-send`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis."configuration-name".block-on-non-durable-send+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+Whether producers block when sending non-durable messages.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_ARTEMIS_BLOCK_ON_NON_DURABLE_SEND+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_ARTEMIS_BLOCK_ON_NON_DURABLE_SEND+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|
+
+a| [[quarkus-artemis-core_quarkus-artemis-pre-acknowledge]] [.property-path]##link:#quarkus-artemis-core_quarkus-artemis-pre-acknowledge[`quarkus.artemis.pre-acknowledge`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis.pre-acknowledge+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`quarkus.artemis."configuration-name".pre-acknowledge`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis."configuration-name".pre-acknowledge+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+Whether messages are pre-acknowledged on the server.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_ARTEMIS_PRE_ACKNOWLEDGE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_ARTEMIS_PRE_ACKNOWLEDGE+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|
+
+a| [[quarkus-artemis-core_quarkus-artemis-initial-message-packet-size]] [.property-path]##link:#quarkus-artemis-core_quarkus-artemis-initial-message-packet-size[`quarkus.artemis.initial-message-packet-size`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis.initial-message-packet-size+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`quarkus.artemis."configuration-name".initial-message-packet-size`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis."configuration-name".initial-message-packet-size+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+The initial size of message packets in bytes.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_ARTEMIS_INITIAL_MESSAGE_PACKET_SIZE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_ARTEMIS_INITIAL_MESSAGE_PACKET_SIZE+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a| [[quarkus-artemis-core_quarkus-artemis-ack-batch-size]] [.property-path]##link:#quarkus-artemis-core_quarkus-artemis-ack-batch-size[`quarkus.artemis.ack-batch-size`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis.ack-batch-size+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`quarkus.artemis."configuration-name".ack-batch-size`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis."configuration-name".ack-batch-size+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+Core Only: The acknowledgments batch size.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_ARTEMIS_ACK_BATCH_SIZE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_ARTEMIS_ACK_BATCH_SIZE+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a| [[quarkus-artemis-core_quarkus-artemis-on-message-close-timeout]] [.property-path]##link:#quarkus-artemis-core_quarkus-artemis-on-message-close-timeout[`quarkus.artemis.on-message-close-timeout`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis.on-message-close-timeout+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`quarkus.artemis."configuration-name".on-message-close-timeout`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis."configuration-name".on-message-close-timeout+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+Core Only: Timeout (ms) for onMessage completion when closing consumers.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_ARTEMIS_ON_MESSAGE_CLOSE_TIMEOUT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_ARTEMIS_ON_MESSAGE_CLOSE_TIMEOUT+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a| [[quarkus-artemis-core_quarkus-artemis-use-topology-for-load-balancing]] [.property-path]##link:#quarkus-artemis-core_quarkus-artemis-use-topology-for-load-balancing[`quarkus.artemis.use-topology-for-load-balancing`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis.use-topology-for-load-balancing+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`quarkus.artemis."configuration-name".use-topology-for-load-balancing`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis."configuration-name".use-topology-for-load-balancing+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+Core Only: Whether to use cluster topology for load balancing.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_ARTEMIS_USE_TOPOLOGY_FOR_LOAD_BALANCING+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_ARTEMIS_USE_TOPOLOGY_FOR_LOAD_BALANCING+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|
+
+a| [[quarkus-artemis-core_quarkus-artemis-client-id]] [.property-path]##link:#quarkus-artemis-core_quarkus-artemis-client-id[`quarkus.artemis.client-id`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis.client-id+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`quarkus.artemis."configuration-name".client-id`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis."configuration-name".client-id+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+JMS Only: The client ID for the connection.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_ARTEMIS_CLIENT_ID+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_ARTEMIS_CLIENT_ID+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-artemis-core_quarkus-artemis-enable-shared-client-id]] [.property-path]##link:#quarkus-artemis-core_quarkus-artemis-enable-shared-client-id[`quarkus.artemis.enable-shared-client-id`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis.enable-shared-client-id+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`quarkus.artemis."configuration-name".enable-shared-client-id`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis."configuration-name".enable-shared-client-id+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+JMS Only: Whether multiple connections can share the same client ID.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_ARTEMIS_ENABLE_SHARED_CLIENT_ID+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_ARTEMIS_ENABLE_SHARED_CLIENT_ID+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|
+
+a| [[quarkus-artemis-core_quarkus-artemis-enable1x-prefixes]] [.property-path]##link:#quarkus-artemis-core_quarkus-artemis-enable1x-prefixes[`quarkus.artemis.enable1x-prefixes`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis.enable1x-prefixes+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`quarkus.artemis."configuration-name".enable1x-prefixes`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis."configuration-name".enable1x-prefixes+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+JMS Only: Whether to use 1.x message prefixes (jms.queue.).
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_ARTEMIS_ENABLE1X_PREFIXES+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_ARTEMIS_ENABLE1X_PREFIXES+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|
+
+a| [[quarkus-artemis-core_quarkus-artemis-ignore-jta]] [.property-path]##link:#quarkus-artemis-core_quarkus-artemis-ignore-jta[`quarkus.artemis.ignore-jta`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis.ignore-jta+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`quarkus.artemis."configuration-name".ignore-jta`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis."configuration-name".ignore-jta+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+JMS Only: Whether to ignore JTA for session management.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_ARTEMIS_IGNORE_JTA+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_ARTEMIS_IGNORE_JTA+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|
+
+a| [[quarkus-artemis-core_quarkus-artemis-dups-ok-batch-size]] [.property-path]##link:#quarkus-artemis-core_quarkus-artemis-dups-ok-batch-size[`quarkus.artemis.dups-ok-batch-size`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis.dups-ok-batch-size+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`quarkus.artemis."configuration-name".dups-ok-batch-size`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis."configuration-name".dups-ok-batch-size+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+JMS Only: The batch size for DUPS_OK_ACKNOWLEDGE mode.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_ARTEMIS_DUPS_OK_BATCH_SIZE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_ARTEMIS_DUPS_OK_BATCH_SIZE+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a| [[quarkus-artemis-core_quarkus-artemis-transaction-batch-size]] [.property-path]##link:#quarkus-artemis-core_quarkus-artemis-transaction-batch-size[`quarkus.artemis.transaction-batch-size`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis.transaction-batch-size+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`quarkus.artemis."configuration-name".transaction-batch-size`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis."configuration-name".transaction-batch-size+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+JMS Only: The batch size for transacted sessions in bytes.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_ARTEMIS_TRANSACTION_BATCH_SIZE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_ARTEMIS_TRANSACTION_BATCH_SIZE+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a| [[quarkus-artemis-core_quarkus-artemis-cache-destinations]] [.property-path]##link:#quarkus-artemis-core_quarkus-artemis-cache-destinations[`quarkus.artemis.cache-destinations`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis.cache-destinations+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`quarkus.artemis."configuration-name".cache-destinations`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis."configuration-name".cache-destinations+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+JMS Only: Whether to cache JMS destinations on the client.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_ARTEMIS_CACHE_DESTINATIONS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_ARTEMIS_CACHE_DESTINATIONS+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|
+
+a| [[quarkus-artemis-core_quarkus-artemis-deserialization-white-list]] [.property-path]##link:#quarkus-artemis-core_quarkus-artemis-deserialization-white-list[`quarkus.artemis.deserialization-white-list`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis.deserialization-white-list+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`quarkus.artemis."configuration-name".deserialization-white-list`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis."configuration-name".deserialization-white-list+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+JMS Only: Allowed classes for ObjectMessage deserialization.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_ARTEMIS_DESERIALIZATION_WHITE_LIST+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_ARTEMIS_DESERIALIZATION_WHITE_LIST+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-artemis-core_quarkus-artemis-deserialization-black-list]] [.property-path]##link:#quarkus-artemis-core_quarkus-artemis-deserialization-black-list[`quarkus.artemis.deserialization-black-list`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis.deserialization-black-list+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`quarkus.artemis."configuration-name".deserialization-black-list`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis."configuration-name".deserialization-black-list+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+JMS Only: Forbidden classes for ObjectMessage deserialization.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_ARTEMIS_DESERIALIZATION_BLACK_LIST+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_ARTEMIS_DESERIALIZATION_BLACK_LIST+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-artemis-core_quarkus-artemis-incoming-interceptor-list]] [.property-path]##link:#quarkus-artemis-core_quarkus-artemis-incoming-interceptor-list[`quarkus.artemis.incoming-interceptor-list`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis.incoming-interceptor-list+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`quarkus.artemis."configuration-name".incoming-interceptor-list`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis."configuration-name".incoming-interceptor-list+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+Comma-separated list of incoming interceptors.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_ARTEMIS_INCOMING_INTERCEPTOR_LIST+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_ARTEMIS_INCOMING_INTERCEPTOR_LIST+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-artemis-core_quarkus-artemis-outgoing-interceptor-list]] [.property-path]##link:#quarkus-artemis-core_quarkus-artemis-outgoing-interceptor-list[`quarkus.artemis.outgoing-interceptor-list`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis.outgoing-interceptor-list+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`quarkus.artemis."configuration-name".outgoing-interceptor-list`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis."configuration-name".outgoing-interceptor-list+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+Comma-separated list of outgoing interceptors.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_ARTEMIS_OUTGOING_INTERCEPTOR_LIST+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_ARTEMIS_OUTGOING_INTERCEPTOR_LIST+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-artemis-core_quarkus-artemis-connection-load-balancing-policy-class-name]] [.property-path]##link:#quarkus-artemis-core_quarkus-artemis-connection-load-balancing-policy-class-name[`quarkus.artemis.connection-load-balancing-policy-class-name`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis.connection-load-balancing-policy-class-name+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`quarkus.artemis."configuration-name".connection-load-balancing-policy-class-name`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis."configuration-name".connection-load-balancing-policy-class-name+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+Class name of the connection load balancing policy.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_ARTEMIS_CONNECTION_LOAD_BALANCING_POLICY_CLASS_NAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_ARTEMIS_CONNECTION_LOAD_BALANCING_POLICY_CLASS_NAME+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-artemis-core_quarkus-artemis-protocol-manager-factory-str]] [.property-path]##link:#quarkus-artemis-core_quarkus-artemis-protocol-manager-factory-str[`quarkus.artemis.protocol-manager-factory-str`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis.protocol-manager-factory-str+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`quarkus.artemis."configuration-name".protocol-manager-factory-str`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis."configuration-name".protocol-manager-factory-str+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+Class name of the protocol manager factory.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_ARTEMIS_PROTOCOL_MANAGER_FACTORY_STR+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_ARTEMIS_PROTOCOL_MANAGER_FACTORY_STR+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
 |
 
 

--- a/integration-tests/core/pom.xml
+++ b/integration-tests/core/pom.xml
@@ -20,6 +20,7 @@
         <module>with-default-change-url</module>
         <module>with-default-dynamic-port</module>
         <module>with-external</module>
+        <module>with-locator-customization</module>
         <module>without-default</module>
     </modules>
 

--- a/integration-tests/core/with-locator-customization/pom.xml
+++ b/integration-tests/core/with-locator-customization/pom.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.quarkiverse.artemis</groupId>
+        <artifactId>quarkus-integration-test-artemis-core-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>quarkus-integration-test-artemis-core-with-locator-customization</artifactId>
+    <name>Quarkus - Artemis - Integration Tests - Core - With locator customization</name>
+    <description>The Apache ActiveMQ Artemis Core integration with locator customization tests module</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkiverse.artemis</groupId>
+            <artifactId>quarkus-integration-test-artemis-core-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkiverse.artemis</groupId>
+            <artifactId>quarkus-integration-test-artemis-core-common</artifactId>
+            <classifier>tests</classifier>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/integration-tests/core/with-locator-customization/src/main/java/io/quarkus/it/artemis/core/withlocatorcustomization/ArtemisEndpoint.java
+++ b/integration-tests/core/with-locator-customization/src/main/java/io/quarkus/it/artemis/core/withlocatorcustomization/ArtemisEndpoint.java
@@ -1,0 +1,60 @@
+package io.quarkus.it.artemis.core.withlocatorcustomization;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import org.apache.activemq.artemis.api.core.client.ServerLocator;
+
+import io.smallrye.common.annotation.Identifier;
+
+@Path("/artemis")
+@Produces(MediaType.TEXT_PLAIN)
+public class ArtemisEndpoint {
+    private final ServerLocator defaultLocator;
+    private final ServerLocator namedOneLocator;
+
+    public ArtemisEndpoint(
+            @SuppressWarnings("CdiInjectionPointsInspection") ServerLocator defaultLocator,
+            @SuppressWarnings("CdiInjectionPointsInspection") @Identifier("named-1") ServerLocator namedOneLocator) {
+        this.defaultLocator = defaultLocator;
+        this.namedOneLocator = namedOneLocator;
+    }
+
+    @GET
+    @Path("/default/consumer-window-size")
+    public int getDefaultConsumerWindowSize() {
+        return defaultLocator.getConsumerWindowSize();
+    }
+
+    @GET
+    @Path("/default/call-timeout")
+    public long getDefaultCallTimeout() {
+        return defaultLocator.getCallTimeout();
+    }
+
+    @GET
+    @Path("/default/auto-group")
+    public boolean getDefaultAutoGroup() {
+        return defaultLocator.isAutoGroup();
+    }
+
+    @GET
+    @Path("/named-1/producer-max-rate")
+    public int getNamedOneProducerMaxRate() {
+        return namedOneLocator.getProducerMaxRate();
+    }
+
+    @GET
+    @Path("/named-1/retry-interval-multiplier")
+    public double getNamedOneRetryIntervalMultiplier() {
+        return namedOneLocator.getRetryIntervalMultiplier();
+    }
+
+    @GET
+    @Path("/named-1/pre-acknowledge")
+    public boolean getNamedOnePreAcknowledge() {
+        return namedOneLocator.isPreAcknowledge();
+    }
+}

--- a/integration-tests/core/with-locator-customization/src/main/java/io/quarkus/it/artemis/core/withlocatorcustomization/BeanProducer.java
+++ b/integration-tests/core/with-locator-customization/src/main/java/io/quarkus/it/artemis/core/withlocatorcustomization/BeanProducer.java
@@ -1,0 +1,47 @@
+package io.quarkus.it.artemis.core.withlocatorcustomization;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+
+import org.apache.activemq.artemis.api.core.client.ServerLocator;
+
+import io.quarkus.it.artemis.core.common.ArtemisCoreConsumerManager;
+import io.quarkus.it.artemis.core.common.ArtemisCoreProducerManager;
+import io.smallrye.common.annotation.Identifier;
+
+public class BeanProducer {
+    @Produces
+    @ApplicationScoped
+    ArtemisCoreConsumerManager defaultConsumer(@SuppressWarnings("CdiInjectionPointsInspection") ServerLocator serverLocator)
+            throws Exception {
+        return new ArtemisCoreConsumerManager(serverLocator, "test-core-default");
+    }
+
+    @Produces
+    @ApplicationScoped
+    @Identifier("named-1")
+    ArtemisCoreConsumerManager namedOneConsumer(
+            @SuppressWarnings("CdiInjectionPointsInspection") @Identifier("named-1") ServerLocator namedOneServerLocator)
+            throws Exception {
+        return new ArtemisCoreConsumerManager(namedOneServerLocator, "test-core-named-1");
+    }
+
+    @Produces
+    @ApplicationScoped
+    ArtemisCoreProducerManager defaultProducer(
+            @SuppressWarnings("CdiInjectionPointsInspection") ServerLocator serverLocator) throws Exception {
+        return new ArtemisCoreProducerManager(serverLocator, "test-core-default");
+    }
+
+    @Produces
+    @ApplicationScoped
+    @Identifier("named-1")
+    ArtemisCoreProducerManager namedOneProducer(
+            @SuppressWarnings("CdiInjectionPointsInspection") @Identifier("named-1") ServerLocator namedOneServerLocator)
+            throws Exception {
+        return new ArtemisCoreProducerManager(namedOneServerLocator, "test-core-named-1");
+    }
+
+    BeanProducer() {
+    }
+}

--- a/integration-tests/core/with-locator-customization/src/main/resources/application.properties
+++ b/integration-tests/core/with-locator-customization/src/main/resources/application.properties
@@ -1,0 +1,19 @@
+quarkus.artemis.devservices.enabled=false
+quarkus.artemis.health-exclude=true
+quarkus.artemis."named-1".devservices.enabled=false
+quarkus.artemis."named-2".enabled=false
+
+# Default Factory Configs
+quarkus.artemis.consumer-window-size=2048
+quarkus.artemis.call-timeout=5000
+quarkus.artemis.auto-group=true
+
+# Named-1 Factory Configs
+quarkus.artemis."named-1".producer-max-rate=100
+quarkus.artemis."named-1".retry-interval-multiplier=2.5
+quarkus.artemis."named-1".pre-acknowledge=true
+
+quarkus.http.test-port=0
+
+quarkus.log.category."org.apache.activemq.audit".level=WARN
+quarkus.log.category."org.apache.activemq.artemis.core.server".level=WARN

--- a/integration-tests/core/with-locator-customization/src/test/java/io/quarkus/it/artemis/core/withlocatorcustomization/BaseArtemisCustomizationTest.java
+++ b/integration-tests/core/with-locator-customization/src/test/java/io/quarkus/it/artemis/core/withlocatorcustomization/BaseArtemisCustomizationTest.java
@@ -1,0 +1,52 @@
+package io.quarkus.it.artemis.core.withlocatorcustomization;
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.it.artemis.core.common.ArtemisCoreHelper;
+import io.restassured.RestAssured;
+
+public abstract class BaseArtemisCustomizationTest extends ArtemisCoreHelper {
+
+    @Test
+    void testDefaultConfig() {
+        RestAssured.when()
+                .get("/artemis/default/consumer-window-size")
+                .then()
+                .statusCode(200)
+                .body(Matchers.is("2048"));
+
+        RestAssured.when()
+                .get("/artemis/default/call-timeout")
+                .then()
+                .statusCode(200)
+                .body(Matchers.is("5000"));
+
+        RestAssured.when()
+                .get("/artemis/default/auto-group")
+                .then()
+                .statusCode(200)
+                .body(Matchers.is("true"));
+    }
+
+    @Test
+    void testNamedOneConfig() {
+        RestAssured.when()
+                .get("/artemis/named-1/producer-max-rate")
+                .then()
+                .statusCode(200)
+                .body(Matchers.is("100"));
+
+        RestAssured.when()
+                .get("/artemis/named-1/retry-interval-multiplier")
+                .then()
+                .statusCode(200)
+                .body(Matchers.is("2.5"));
+
+        RestAssured.when()
+                .get("/artemis/named-1/pre-acknowledge")
+                .then()
+                .statusCode(200)
+                .body(Matchers.is("true"));
+    }
+}

--- a/integration-tests/core/with-locator-customization/src/test/java/io/quarkus/it/artemis/core/withlocatorcustomization/BaseArtemisHealthCheckTest.java
+++ b/integration-tests/core/with-locator-customization/src/test/java/io/quarkus/it/artemis/core/withlocatorcustomization/BaseArtemisHealthCheckTest.java
@@ -1,0 +1,19 @@
+package io.quarkus.it.artemis.core.withlocatorcustomization;
+
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.it.artemis.common.ArtemisHealthCheckHelper;
+
+public abstract class BaseArtemisHealthCheckTest {
+    @Test
+    void testHealth() {
+        ArtemisHealthCheckHelper.testCore("/q/health", Set.of("named-1"));
+    }
+
+    @Test
+    void testReady() {
+        ArtemisHealthCheckHelper.testCore("/q/health/ready", Set.of("named-1"));
+    }
+}

--- a/integration-tests/core/with-locator-customization/src/test/java/io/quarkus/it/artemis/core/withlocatorcustomization/devservices/DevServiceArtemisEnabled.java
+++ b/integration-tests/core/with-locator-customization/src/test/java/io/quarkus/it/artemis/core/withlocatorcustomization/devservices/DevServiceArtemisEnabled.java
@@ -1,0 +1,23 @@
+package io.quarkus.it.artemis.core.withlocatorcustomization.devservices;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import io.quarkus.test.junit.QuarkusTestProfile;
+
+public class DevServiceArtemisEnabled implements QuarkusTestProfile {
+    @Override
+    public Map<String, String> getConfigOverrides() {
+        Map<String, String> props = new HashMap<>();
+        props.put("quarkus.artemis.devservices.enabled", "true");
+        props.put("quarkus.artemis.devservices.extra-args", "--no-autotune --queues test-core-default");
+        props.put("quarkus.artemis.\"named-1\".devservices.enabled", "true");
+        props.put("quarkus.artemis.\"named-1\".devservices.extra-args", "--no-autotune --queues test-core-named-1");
+        return props;
+    }
+
+    @Override
+    public boolean disableGlobalTestResources() {
+        return true;
+    }
+}

--- a/integration-tests/core/with-locator-customization/src/test/java/io/quarkus/it/artemis/core/withlocatorcustomization/devservices/DevservicesCustomizationTest.java
+++ b/integration-tests/core/with-locator-customization/src/test/java/io/quarkus/it/artemis/core/withlocatorcustomization/devservices/DevservicesCustomizationTest.java
@@ -1,0 +1,10 @@
+package io.quarkus.it.artemis.core.withlocatorcustomization.devservices;
+
+import io.quarkus.it.artemis.core.withlocatorcustomization.BaseArtemisCustomizationTest;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+
+@QuarkusTest
+@TestProfile(DevServiceArtemisEnabled.class)
+class DevservicesCustomizationTest extends BaseArtemisCustomizationTest {
+}

--- a/integration-tests/core/with-locator-customization/src/test/java/io/quarkus/it/artemis/core/withlocatorcustomization/devservices/DevservicesHealthCheckTest.java
+++ b/integration-tests/core/with-locator-customization/src/test/java/io/quarkus/it/artemis/core/withlocatorcustomization/devservices/DevservicesHealthCheckTest.java
@@ -1,0 +1,10 @@
+package io.quarkus.it.artemis.core.withlocatorcustomization.devservices;
+
+import io.quarkus.it.artemis.core.withlocatorcustomization.BaseArtemisHealthCheckTest;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+
+@QuarkusTest
+@TestProfile(DevServiceArtemisEnabled.class)
+class DevservicesHealthCheckTest extends BaseArtemisHealthCheckTest {
+}

--- a/integration-tests/core/with-locator-customization/src/test/java/io/quarkus/it/artemis/core/withlocatorcustomization/embedded/EmbeddedCustomizationITCase.java
+++ b/integration-tests/core/with-locator-customization/src/test/java/io/quarkus/it/artemis/core/withlocatorcustomization/embedded/EmbeddedCustomizationITCase.java
@@ -1,0 +1,7 @@
+package io.quarkus.it.artemis.core.withlocatorcustomization.embedded;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+class EmbeddedCustomizationITCase extends EmbeddedCustomizationTest {
+}

--- a/integration-tests/core/with-locator-customization/src/test/java/io/quarkus/it/artemis/core/withlocatorcustomization/embedded/EmbeddedCustomizationTest.java
+++ b/integration-tests/core/with-locator-customization/src/test/java/io/quarkus/it/artemis/core/withlocatorcustomization/embedded/EmbeddedCustomizationTest.java
@@ -1,0 +1,12 @@
+package io.quarkus.it.artemis.core.withlocatorcustomization.embedded;
+
+import io.quarkus.artemis.test.ArtemisTestResource;
+import io.quarkus.it.artemis.core.withlocatorcustomization.BaseArtemisCustomizationTest;
+import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+@WithTestResource(ArtemisTestResource.class)
+@WithTestResource(NamedOneArtemisTestResource.class)
+class EmbeddedCustomizationTest extends BaseArtemisCustomizationTest {
+}

--- a/integration-tests/core/with-locator-customization/src/test/java/io/quarkus/it/artemis/core/withlocatorcustomization/embedded/EmbeddedHealthCheckITCase.java
+++ b/integration-tests/core/with-locator-customization/src/test/java/io/quarkus/it/artemis/core/withlocatorcustomization/embedded/EmbeddedHealthCheckITCase.java
@@ -1,0 +1,7 @@
+package io.quarkus.it.artemis.core.withlocatorcustomization.embedded;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+class EmbeddedHealthCheckITCase extends EmbeddedHealthCheckTest {
+}

--- a/integration-tests/core/with-locator-customization/src/test/java/io/quarkus/it/artemis/core/withlocatorcustomization/embedded/EmbeddedHealthCheckTest.java
+++ b/integration-tests/core/with-locator-customization/src/test/java/io/quarkus/it/artemis/core/withlocatorcustomization/embedded/EmbeddedHealthCheckTest.java
@@ -1,0 +1,12 @@
+package io.quarkus.it.artemis.core.withlocatorcustomization.embedded;
+
+import io.quarkus.artemis.test.ArtemisTestResource;
+import io.quarkus.it.artemis.core.withlocatorcustomization.BaseArtemisHealthCheckTest;
+import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+@WithTestResource(ArtemisTestResource.class)
+@WithTestResource(NamedOneArtemisTestResource.class)
+class EmbeddedHealthCheckTest extends BaseArtemisHealthCheckTest {
+}

--- a/integration-tests/core/with-locator-customization/src/test/java/io/quarkus/it/artemis/core/withlocatorcustomization/embedded/NamedOneArtemisTestResource.java
+++ b/integration-tests/core/with-locator-customization/src/test/java/io/quarkus/it/artemis/core/withlocatorcustomization/embedded/NamedOneArtemisTestResource.java
@@ -1,0 +1,9 @@
+package io.quarkus.it.artemis.core.withlocatorcustomization.embedded;
+
+import io.quarkus.artemis.test.ArtemisTestResource;
+
+public class NamedOneArtemisTestResource extends ArtemisTestResource {
+    public NamedOneArtemisTestResource() {
+        super("named-1");
+    }
+}

--- a/integration-tests/core/with-locator-customization/src/test/resources/broker-named-1.xml
+++ b/integration-tests/core/with-locator-customization/src/test/resources/broker-named-1.xml
@@ -1,0 +1,26 @@
+<configuration xmlns="urn:activemq" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:activemq /schema/artemis-configuration.xsd">
+    <core xmlns="urn:activemq:core">
+        <paging-directory>./target/artemis/named-1/paging</paging-directory>
+        <bindings-directory>./target/artemis/named-1/bindings</bindings-directory>
+        <journal-directory>./target/artemis/named-1/journal</journal-directory>
+        <large-messages-directory>./target/artemis/named-1/large-messages</large-messages-directory>
+
+        <connectors>
+            <connector name="activemq">tcp://localhost:0</connector>
+        </connectors>
+        <acceptors>
+            <acceptor name="activemq">tcp://localhost:0</acceptor>
+        </acceptors>
+
+        <max-disk-usage>-1</max-disk-usage>
+        <security-enabled>false</security-enabled>
+
+        <addresses>
+            <address name="test-core-named-1">
+                <anycast>
+                    <queue name="test-core-named-1"/>
+                </anycast>
+            </address>
+        </addresses>
+    </core>
+</configuration>

--- a/integration-tests/core/with-locator-customization/src/test/resources/broker.xml
+++ b/integration-tests/core/with-locator-customization/src/test/resources/broker.xml
@@ -1,0 +1,26 @@
+<configuration xmlns="urn:activemq" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:activemq /schema/artemis-configuration.xsd">
+    <core xmlns="urn:activemq:core">
+        <paging-directory>./target/artemis/default/paging</paging-directory>
+        <bindings-directory>./target/artemis/default/bindings</bindings-directory>
+        <journal-directory>./target/artemis/default/journal</journal-directory>
+        <large-messages-directory>./target/artemis/default/large-messages</large-messages-directory>
+
+        <connectors>
+            <connector name="activemq">tcp://localhost:0</connector>
+        </connectors>
+        <acceptors>
+            <acceptor name="activemq">tcp://localhost:0</acceptor>
+        </acceptors>
+
+        <max-disk-usage>-1</max-disk-usage>
+        <security-enabled>false</security-enabled>
+
+        <addresses>
+            <address name="test-core-default">
+                <anycast>
+                    <queue name="test-core-default"/>
+                </anycast>
+            </address>
+        </addresses>
+    </core>
+</configuration>

--- a/integration-tests/jms/pom.xml
+++ b/integration-tests/jms/pom.xml
@@ -19,6 +19,7 @@
         <module>with-default-and-external</module>
         <module>with-default-change-url</module>
         <module>with-external</module>
+        <module>with-factory-customization</module>
         <module>without-default</module>
     </modules>
 

--- a/integration-tests/jms/with-factory-customization/pom.xml
+++ b/integration-tests/jms/with-factory-customization/pom.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.quarkiverse.artemis</groupId>
+        <artifactId>quarkus-integration-test-artemis-jms-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>quarkus-integration-test-artemis-jms-with-factory-customization</artifactId>
+    <name>Quarkus - Artemis - Integration Tests - JMS - With factory customization</name>
+    <description>The Apache ActiveMQ Artemis JMS integration with factory customization tests module</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkiverse.artemis</groupId>
+            <artifactId>quarkus-integration-test-artemis-jms-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkiverse.artemis</groupId>
+            <artifactId>quarkus-integration-test-artemis-jms-common</artifactId>
+            <classifier>tests</classifier>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/integration-tests/jms/with-factory-customization/src/main/java/io/quarkus/it/artemis/core/withfactorycustomization/ArtemisEndpoint.java
+++ b/integration-tests/jms/with-factory-customization/src/main/java/io/quarkus/it/artemis/core/withfactorycustomization/ArtemisEndpoint.java
@@ -1,0 +1,62 @@
+package io.quarkus.it.artemis.core.withfactorycustomization;
+
+import jakarta.jms.ConnectionFactory;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
+
+import io.quarkus.arc.ClientProxy;
+import io.smallrye.common.annotation.Identifier;
+
+@Path("/artemis")
+@Produces(MediaType.TEXT_PLAIN)
+public class ArtemisEndpoint {
+    private final ActiveMQConnectionFactory defaultFactory;
+    private final ActiveMQConnectionFactory namedOneFactory;
+
+    public ArtemisEndpoint(
+            @SuppressWarnings("CdiInjectionPointsInspection") ConnectionFactory defaultFactory,
+            @SuppressWarnings("CdiInjectionPointsInspection") @Identifier("named-1") ConnectionFactory namedOneFactory) {
+        this.defaultFactory = (ActiveMQConnectionFactory) ClientProxy.unwrap(defaultFactory);
+        this.namedOneFactory = (ActiveMQConnectionFactory) ClientProxy.unwrap(namedOneFactory);
+    }
+
+    @GET
+    @Path("/default/consumer-window-size")
+    public int getDefaultConsumerWindowSize() {
+        return defaultFactory.getConsumerWindowSize();
+    }
+
+    @GET
+    @Path("/default/call-timeout")
+    public long getDefaultCallTimeout() {
+        return defaultFactory.getCallTimeout();
+    }
+
+    @GET
+    @Path("/default/auto-group")
+    public boolean getDefaultAutoGroup() {
+        return defaultFactory.isAutoGroup();
+    }
+
+    @GET
+    @Path("/named-1/producer-max-rate")
+    public int getNamedOneProducerMaxRate() {
+        return namedOneFactory.getProducerMaxRate();
+    }
+
+    @GET
+    @Path("/named-1/retry-interval-multiplier")
+    public double getNamedOneRetryIntervalMultiplier() {
+        return namedOneFactory.getRetryIntervalMultiplier();
+    }
+
+    @GET
+    @Path("/named-1/pre-acknowledge")
+    public boolean getNamedOnePreAcknowledge() {
+        return namedOneFactory.isPreAcknowledge();
+    }
+}

--- a/integration-tests/jms/with-factory-customization/src/main/java/io/quarkus/it/artemis/core/withfactorycustomization/BeanProducer.java
+++ b/integration-tests/jms/with-factory-customization/src/main/java/io/quarkus/it/artemis/core/withfactorycustomization/BeanProducer.java
@@ -1,0 +1,44 @@
+package io.quarkus.it.artemis.core.withfactorycustomization;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+import jakarta.jms.ConnectionFactory;
+
+import io.quarkus.it.artemis.jms.common.ArtemisJmsConsumerManager;
+import io.quarkus.it.artemis.jms.common.ArtemisJmsProducerManager;
+import io.smallrye.common.annotation.Identifier;
+
+public class BeanProducer {
+    @Produces
+    @ApplicationScoped
+    ArtemisJmsConsumerManager defaultConsumerManager(
+            @SuppressWarnings("CdiInjectionPointsInspection") ConnectionFactory defaultConnectionFactory) {
+        return new ArtemisJmsConsumerManager(defaultConnectionFactory, "test-jms-default");
+    }
+
+    @Produces
+    @ApplicationScoped
+    @Identifier("named-1")
+    ArtemisJmsConsumerManager namedOneConsumerManager(
+            @SuppressWarnings("CdiInjectionPointsInspection") @Identifier("named-1") ConnectionFactory namedOneConnectionFactory) {
+        return new ArtemisJmsConsumerManager(namedOneConnectionFactory, "test-jms-named-1");
+    }
+
+    @Produces
+    @ApplicationScoped
+    ArtemisJmsProducerManager defaultProducer(
+            @SuppressWarnings("CdiInjectionPointsInspection") ConnectionFactory defaultConnectionFactory) {
+        return new ArtemisJmsProducerManager(defaultConnectionFactory, "test-jms-default");
+    }
+
+    @Produces
+    @ApplicationScoped
+    @Identifier("named-1")
+    ArtemisJmsProducerManager namedOneProducer(
+            @SuppressWarnings("CdiInjectionPointsInspection") @Identifier("named-1") ConnectionFactory namedOneConnectionFactory) {
+        return new ArtemisJmsProducerManager(namedOneConnectionFactory, "test-jms-named-1");
+    }
+
+    BeanProducer() {
+    }
+}

--- a/integration-tests/jms/with-factory-customization/src/main/resources/application.properties
+++ b/integration-tests/jms/with-factory-customization/src/main/resources/application.properties
@@ -1,0 +1,19 @@
+quarkus.artemis.devservices.enabled=false
+quarkus.artemis.health-exclude=true
+quarkus.artemis."named-1".devservices.enabled=false
+quarkus.artemis."named-2".enabled=false
+
+# Default Factory Configs
+quarkus.artemis.consumer-window-size=2048
+quarkus.artemis.call-timeout=5000
+quarkus.artemis.auto-group=true
+
+# Named-1 Factory Configs
+quarkus.artemis."named-1".producer-max-rate=100
+quarkus.artemis."named-1".retry-interval-multiplier=2.5
+quarkus.artemis."named-1".pre-acknowledge=true
+
+quarkus.http.test-port=0
+
+quarkus.log.category."org.apache.activemq.audit".level=WARN
+quarkus.log.category."org.apache.activemq.artemis.core.server".level=WARN

--- a/integration-tests/jms/with-factory-customization/src/test/java/io/quarkus/it/artemis/core/withfactorycustomization/BaseArtemisCustomizationTest.java
+++ b/integration-tests/jms/with-factory-customization/src/test/java/io/quarkus/it/artemis/core/withfactorycustomization/BaseArtemisCustomizationTest.java
@@ -1,0 +1,52 @@
+package io.quarkus.it.artemis.core.withfactorycustomization;
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.it.artemis.jms.common.ArtemisJmsHelper;
+import io.restassured.RestAssured;
+
+public abstract class BaseArtemisCustomizationTest extends ArtemisJmsHelper {
+
+    @Test
+    void testDefaultConfig() {
+        RestAssured.when()
+                .get("/artemis/default/consumer-window-size")
+                .then()
+                .statusCode(200)
+                .body(Matchers.is("2048"));
+
+        RestAssured.when()
+                .get("/artemis/default/call-timeout")
+                .then()
+                .statusCode(200)
+                .body(Matchers.is("5000"));
+
+        RestAssured.when()
+                .get("/artemis/default/auto-group")
+                .then()
+                .statusCode(200)
+                .body(Matchers.is("true"));
+    }
+
+    @Test
+    void testNamedOneConfig() {
+        RestAssured.when()
+                .get("/artemis/named-1/producer-max-rate")
+                .then()
+                .statusCode(200)
+                .body(Matchers.is("100"));
+
+        RestAssured.when()
+                .get("/artemis/named-1/retry-interval-multiplier")
+                .then()
+                .statusCode(200)
+                .body(Matchers.is("2.5"));
+
+        RestAssured.when()
+                .get("/artemis/named-1/pre-acknowledge")
+                .then()
+                .statusCode(200)
+                .body(Matchers.is("true"));
+    }
+}

--- a/integration-tests/jms/with-factory-customization/src/test/java/io/quarkus/it/artemis/core/withfactorycustomization/BaseArtemisHealthCheckTest.java
+++ b/integration-tests/jms/with-factory-customization/src/test/java/io/quarkus/it/artemis/core/withfactorycustomization/BaseArtemisHealthCheckTest.java
@@ -1,0 +1,19 @@
+package io.quarkus.it.artemis.core.withfactorycustomization;
+
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.it.artemis.common.ArtemisHealthCheckHelper;
+
+public abstract class BaseArtemisHealthCheckTest {
+    @Test
+    void testHealth() {
+        ArtemisHealthCheckHelper.testJms("/q/health", Set.of("named-1"));
+    }
+
+    @Test
+    void testReady() {
+        ArtemisHealthCheckHelper.testJms("/q/health/ready", Set.of("named-1"));
+    }
+}

--- a/integration-tests/jms/with-factory-customization/src/test/java/io/quarkus/it/artemis/core/withfactorycustomization/devservices/DevServiceArtemisEnabled.java
+++ b/integration-tests/jms/with-factory-customization/src/test/java/io/quarkus/it/artemis/core/withfactorycustomization/devservices/DevServiceArtemisEnabled.java
@@ -1,0 +1,23 @@
+package io.quarkus.it.artemis.core.withfactorycustomization.devservices;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import io.quarkus.test.junit.QuarkusTestProfile;
+
+public class DevServiceArtemisEnabled implements QuarkusTestProfile {
+    @Override
+    public Map<String, String> getConfigOverrides() {
+        Map<String, String> props = new HashMap<>();
+        props.put("quarkus.artemis.devservices.enabled", "true");
+        props.put("quarkus.artemis.devservices.extra-args", "--no-autotune --queues test-core-default");
+        props.put("quarkus.artemis.\"named-1\".devservices.enabled", "true");
+        props.put("quarkus.artemis.\"named-1\".devservices.extra-args", "--no-autotune --queues test-core-named-1");
+        return props;
+    }
+
+    @Override
+    public boolean disableGlobalTestResources() {
+        return true;
+    }
+}

--- a/integration-tests/jms/with-factory-customization/src/test/java/io/quarkus/it/artemis/core/withfactorycustomization/devservices/DevservicesCustomizationTest.java
+++ b/integration-tests/jms/with-factory-customization/src/test/java/io/quarkus/it/artemis/core/withfactorycustomization/devservices/DevservicesCustomizationTest.java
@@ -1,0 +1,10 @@
+package io.quarkus.it.artemis.core.withfactorycustomization.devservices;
+
+import io.quarkus.it.artemis.core.withfactorycustomization.BaseArtemisCustomizationTest;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+
+@QuarkusTest
+@TestProfile(DevServiceArtemisEnabled.class)
+class DevservicesCustomizationTest extends BaseArtemisCustomizationTest {
+}

--- a/integration-tests/jms/with-factory-customization/src/test/java/io/quarkus/it/artemis/core/withfactorycustomization/devservices/DevservicesHealthCheckTest.java
+++ b/integration-tests/jms/with-factory-customization/src/test/java/io/quarkus/it/artemis/core/withfactorycustomization/devservices/DevservicesHealthCheckTest.java
@@ -1,0 +1,10 @@
+package io.quarkus.it.artemis.core.withfactorycustomization.devservices;
+
+import io.quarkus.it.artemis.core.withfactorycustomization.BaseArtemisHealthCheckTest;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+
+@QuarkusTest
+@TestProfile(DevServiceArtemisEnabled.class)
+class DevservicesHealthCheckTest extends BaseArtemisHealthCheckTest {
+}

--- a/integration-tests/jms/with-factory-customization/src/test/java/io/quarkus/it/artemis/core/withfactorycustomization/embedded/EmbeddedCustomizationITCase.java
+++ b/integration-tests/jms/with-factory-customization/src/test/java/io/quarkus/it/artemis/core/withfactorycustomization/embedded/EmbeddedCustomizationITCase.java
@@ -1,0 +1,7 @@
+package io.quarkus.it.artemis.core.withfactorycustomization.embedded;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+class EmbeddedCustomizationITCase extends EmbeddedCustomizationTest {
+}

--- a/integration-tests/jms/with-factory-customization/src/test/java/io/quarkus/it/artemis/core/withfactorycustomization/embedded/EmbeddedCustomizationTest.java
+++ b/integration-tests/jms/with-factory-customization/src/test/java/io/quarkus/it/artemis/core/withfactorycustomization/embedded/EmbeddedCustomizationTest.java
@@ -1,0 +1,12 @@
+package io.quarkus.it.artemis.core.withfactorycustomization.embedded;
+
+import io.quarkus.artemis.test.ArtemisTestResource;
+import io.quarkus.it.artemis.core.withfactorycustomization.BaseArtemisCustomizationTest;
+import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+@WithTestResource(ArtemisTestResource.class)
+@WithTestResource(NamedOneArtemisTestResource.class)
+class EmbeddedCustomizationTest extends BaseArtemisCustomizationTest {
+}

--- a/integration-tests/jms/with-factory-customization/src/test/java/io/quarkus/it/artemis/core/withfactorycustomization/embedded/EmbeddedHealthCheckITCase.java
+++ b/integration-tests/jms/with-factory-customization/src/test/java/io/quarkus/it/artemis/core/withfactorycustomization/embedded/EmbeddedHealthCheckITCase.java
@@ -1,0 +1,7 @@
+package io.quarkus.it.artemis.core.withfactorycustomization.embedded;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+class EmbeddedHealthCheckITCase extends EmbeddedHealthCheckTest {
+}

--- a/integration-tests/jms/with-factory-customization/src/test/java/io/quarkus/it/artemis/core/withfactorycustomization/embedded/EmbeddedHealthCheckTest.java
+++ b/integration-tests/jms/with-factory-customization/src/test/java/io/quarkus/it/artemis/core/withfactorycustomization/embedded/EmbeddedHealthCheckTest.java
@@ -1,0 +1,12 @@
+package io.quarkus.it.artemis.core.withfactorycustomization.embedded;
+
+import io.quarkus.artemis.test.ArtemisTestResource;
+import io.quarkus.it.artemis.core.withfactorycustomization.BaseArtemisHealthCheckTest;
+import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+@WithTestResource(ArtemisTestResource.class)
+@WithTestResource(NamedOneArtemisTestResource.class)
+class EmbeddedHealthCheckTest extends BaseArtemisHealthCheckTest {
+}

--- a/integration-tests/jms/with-factory-customization/src/test/java/io/quarkus/it/artemis/core/withfactorycustomization/embedded/NamedOneArtemisTestResource.java
+++ b/integration-tests/jms/with-factory-customization/src/test/java/io/quarkus/it/artemis/core/withfactorycustomization/embedded/NamedOneArtemisTestResource.java
@@ -1,0 +1,9 @@
+package io.quarkus.it.artemis.core.withfactorycustomization.embedded;
+
+import io.quarkus.artemis.test.ArtemisTestResource;
+
+public class NamedOneArtemisTestResource extends ArtemisTestResource {
+    public NamedOneArtemisTestResource() {
+        super("named-1");
+    }
+}

--- a/integration-tests/jms/with-factory-customization/src/test/resources/broker-named-1.xml
+++ b/integration-tests/jms/with-factory-customization/src/test/resources/broker-named-1.xml
@@ -1,0 +1,26 @@
+<configuration xmlns="urn:activemq" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:activemq /schema/artemis-configuration.xsd">
+    <core xmlns="urn:activemq:core">
+        <paging-directory>./target/artemis/named-1/paging</paging-directory>
+        <bindings-directory>./target/artemis/named-1/bindings</bindings-directory>
+        <journal-directory>./target/artemis/named-1/journal</journal-directory>
+        <large-messages-directory>./target/artemis/named-1/large-messages</large-messages-directory>
+
+        <connectors>
+            <connector name="activemq">tcp://localhost:0</connector>
+        </connectors>
+        <acceptors>
+            <acceptor name="activemq">tcp://localhost:0</acceptor>
+        </acceptors>
+
+        <max-disk-usage>-1</max-disk-usage>
+        <security-enabled>false</security-enabled>
+
+        <addresses>
+            <address name="test-core-named-1">
+                <anycast>
+                    <queue name="test-core-named-1"/>
+                </anycast>
+            </address>
+        </addresses>
+    </core>
+</configuration>

--- a/integration-tests/jms/with-factory-customization/src/test/resources/broker.xml
+++ b/integration-tests/jms/with-factory-customization/src/test/resources/broker.xml
@@ -1,0 +1,26 @@
+<configuration xmlns="urn:activemq" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:activemq /schema/artemis-configuration.xsd">
+    <core xmlns="urn:activemq:core">
+        <paging-directory>./target/artemis/default/paging</paging-directory>
+        <bindings-directory>./target/artemis/default/bindings</bindings-directory>
+        <journal-directory>./target/artemis/default/journal</journal-directory>
+        <large-messages-directory>./target/artemis/default/large-messages</large-messages-directory>
+
+        <connectors>
+            <connector name="activemq">tcp://localhost:0</connector>
+        </connectors>
+        <acceptors>
+            <acceptor name="activemq">tcp://localhost:0</acceptor>
+        </acceptors>
+
+        <max-disk-usage>-1</max-disk-usage>
+        <security-enabled>false</security-enabled>
+
+        <addresses>
+            <address name="test-core-default">
+                <anycast>
+                    <queue name="test-core-default"/>
+                </anycast>
+            </address>
+        </addresses>
+    </core>
+</configuration>

--- a/jms/runtime/src/main/java/io/quarkus/artemis/jms/runtime/ArtemisJmsRecorder.java
+++ b/jms/runtime/src/main/java/io/quarkus/artemis/jms/runtime/ArtemisJmsRecorder.java
@@ -44,17 +44,75 @@ public class ArtemisJmsRecorder {
             Function<ConnectionFactory, Object> wrapper) {
         String url = runtimeConfig.getUrl();
         if (url != null) {
+            ActiveMQConnectionFactory cf;
             if (isXaEnabled) {
-                return (ConnectionFactory) wrapper.apply(new ActiveMQXAConnectionFactory(
+                cf = (ActiveMQConnectionFactory) wrapper.apply(new ActiveMQXAConnectionFactory(
                         url,
                         runtimeConfig.getUsername(),
                         runtimeConfig.getPassword()));
             } else {
-                return (ConnectionFactory) wrapper.apply(new ActiveMQConnectionFactory(
+                cf = (ActiveMQConnectionFactory) wrapper.apply(new ActiveMQConnectionFactory(
                         url,
                         runtimeConfig.getUsername(),
                         runtimeConfig.getPassword()));
             }
+
+            // --- Flow Control ---
+            runtimeConfig.consumerWindowSize().ifPresent(cf::setConsumerWindowSize);
+            runtimeConfig.consumerMaxRate().ifPresent(cf::setConsumerMaxRate);
+            runtimeConfig.producerWindowSize().ifPresent(cf::setProducerWindowSize);
+            runtimeConfig.producerMaxRate().ifPresent(cf::setProducerMaxRate);
+            runtimeConfig.confirmationWindowSize().ifPresent(cf::setConfirmationWindowSize);
+            runtimeConfig.minLargeMessageSize().ifPresent(cf::setMinLargeMessageSize);
+            runtimeConfig.compressLargeMessage().ifPresent(cf::setCompressLargeMessage);
+            runtimeConfig.compressionLevel().ifPresent(cf::setCompressionLevel);
+            runtimeConfig.cacheLargeMessagesClient().ifPresent(cf::setCacheLargeMessagesClient);
+
+            // --- Connectivity & Timeouts ---
+            runtimeConfig.clientFailureCheckPeriod().ifPresent(cf::setClientFailureCheckPeriod);
+            runtimeConfig.connectionTtl().ifPresent(cf::setConnectionTTL);
+            runtimeConfig.callTimeout().ifPresent(cf::setCallTimeout);
+            runtimeConfig.callFailoverTimeout().ifPresent(cf::setCallFailoverTimeout);
+            runtimeConfig.useGlobalPools().ifPresent(cf::setUseGlobalPools);
+            runtimeConfig.scheduledThreadPoolMaxSize().ifPresent(cf::setScheduledThreadPoolMaxSize);
+            runtimeConfig.threadPoolMaxSize().ifPresent(cf::setThreadPoolMaxSize);
+
+            // --- Retries & Failover ---
+            runtimeConfig.reconnectAttempts().ifPresent(cf::setReconnectAttempts);
+            runtimeConfig.initialConnectAttempts().ifPresent(cf::setInitialConnectAttempts);
+            runtimeConfig.retryInterval().ifPresent(cf::setRetryInterval);
+            runtimeConfig.retryIntervalMultiplier().ifPresent(cf::setRetryIntervalMultiplier);
+            runtimeConfig.maxRetryInterval().ifPresent(cf::setMaxRetryInterval);
+            runtimeConfig.failoverOnInitialConnection().ifPresent(cf::setFailoverOnInitialConnection);
+
+            // --- Behavior & Grouping ---
+            runtimeConfig.autoGroup().ifPresent(cf::setAutoGroup);
+            runtimeConfig.groupID().ifPresent(cf::setGroupID);
+            runtimeConfig.blockOnAcknowledge().ifPresent(cf::setBlockOnAcknowledge);
+            runtimeConfig.blockOnDurableSend().ifPresent(cf::setBlockOnDurableSend);
+            runtimeConfig.blockOnNonDurableSend().ifPresent(cf::setBlockOnNonDurableSend);
+            runtimeConfig.preAcknowledge().ifPresent(cf::setPreAcknowledge);
+            runtimeConfig.dupsOKBatchSize().ifPresent(cf::setDupsOKBatchSize);
+            runtimeConfig.transactionBatchSize().ifPresent(cf::setTransactionBatchSize);
+            runtimeConfig.cacheDestinations().ifPresent(cf::setCacheDestinations);
+
+            // --- Security & Policy ---
+            runtimeConfig.deserializationWhiteList().ifPresent(cf::setDeserializationWhiteList);
+            runtimeConfig.deserializationBlackList().ifPresent(cf::setDeserializationBlackList);
+            runtimeConfig.incomingInterceptorList().ifPresent(cf::setIncomingInterceptorList);
+            runtimeConfig.outgoingInterceptorList().ifPresent(cf::setOutgoingInterceptorList);
+            runtimeConfig.connectionLoadBalancingPolicyClassName().ifPresent(cf::setConnectionLoadBalancingPolicyClassName);
+            runtimeConfig.protocolManagerFactoryStr().ifPresent(cf::setProtocolManagerFactoryStr);
+
+            // --- Compatibility & Identification ---
+            runtimeConfig.clientID().ifPresent(cf::setClientID);
+            runtimeConfig.enableSharedClientID().ifPresent(cf::setEnableSharedClientID);
+            runtimeConfig.enable1xPrefixes().ifPresent(cf::setEnable1xPrefixes);
+            runtimeConfig.ignoreJTA().ifPresent(cf::setIgnoreJTA);
+            runtimeConfig.useTopologyForLoadBalancing().ifPresent(cf::setUseTopologyForLoadBalancing);
+            runtimeConfig.initialMessagePacketSize().ifPresent(cf::setInitialMessagePacketSize);
+
+            return cf;
         } else {
             return null;
         }


### PR DESCRIPTION
Now you can apply all the configs for `ServiceLocator` and `ConnectionFactory` via application properties.

For example:
```properties
quarkus.artemis.consumer-window-size=2048
quarkus.artemis.call-timeout=5000
quarkus.artemis.auto-group=true

quarkus.artemis."named-1".producer-max-rate=100
quarkus.artemis."named-1".retry-interval-multiplier=2.5
quarkus.artemis."named-1".pre-acknowledge=true
```