### PR TITLE
Expose jvm args to devservice with max disk usage disabled by default

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/artemis/core/deployment/DevServicesArtemisProcessor.java
+++ b/core/deployment/src/main/java/io/quarkus/artemis/core/deployment/DevServicesArtemisProcessor.java
@@ -263,7 +263,8 @@ public class DevServicesArtemisProcessor {
                     config.webUiPort,
                     config.user,
                     config.password,
-                    mergeExtraArgs(config.defaultExtraArgs, config.extraArgs));
+                    mergeExtraArgs(config.defaultExtraArgs, config.extraArgs),
+                    config.javaArgs);
 
             ConfigureUtil.configureSharedNetwork(container, "artemis");
 
@@ -323,6 +324,7 @@ public class DevServicesArtemisProcessor {
         private final String password;
         private final String extraArgs;
         private final String defaultExtraArgs;
+        private final String javaArgs;
 
         public ArtemisDevServiceCfg(ArtemisBuildTimeConfig config, String name, boolean isUrlEmpty) {
             ArtemisDevServicesBuildTimeConfig devServicesConfig = config.getDevservices();
@@ -336,6 +338,7 @@ public class DevServicesArtemisProcessor {
             this.password = devServicesConfig.getPassword();
             this.extraArgs = devServicesConfig.getExtraArgs();
             this.defaultExtraArgs = devServicesConfig.getDefaultExtraArgs();
+            this.javaArgs = devServicesConfig.getJavaArgs();
         }
 
         @Override
@@ -366,7 +369,7 @@ public class DevServicesArtemisProcessor {
         private final int webUiPort;
 
         private ArtemisContainer(DockerImageName dockerImageName, int fixedExposedPort, int webUiPort, String user,
-                String password, String extra) {
+                String password, String extra, String javaArgs) {
             super(dockerImageName);
             this.port = fixedExposedPort;
             this.webUiPort = webUiPort;
@@ -376,6 +379,7 @@ public class DevServicesArtemisProcessor {
                     .withEnv("AMQ_USER", user)
                     .withEnv("AMQ_PASSWORD", password)
                     .withEnv("AMQ_EXTRA_ARGS", extra)
+                    .withEnv("JAVA_ARGS_APPEND", javaArgs)
                     .waitingFor(Wait.forLogMessage(".*AMQ241004.*", 1)); // Artemis console available.
         }
 

--- a/core/runtime/src/main/java/io/quarkus/artemis/core/runtime/ArtemisDevServicesBuildTimeConfig.java
+++ b/core/runtime/src/main/java/io/quarkus/artemis/core/runtime/ArtemisDevServicesBuildTimeConfig.java
@@ -86,6 +86,13 @@ public interface ArtemisDevServicesBuildTimeConfig {
      */
     Optional<String> defaultExtraArgs();
 
+    /**
+     * Value to pass into the {@code JAVA_ARGS_APPEND} environment variable in the container.
+     * <p>
+     * Defaults to {@code -Dbrokerconfig.maxDiskUsage=-1} when not set.
+     */
+    Optional<String> javaArgs();
+
     default boolean isEnabled() {
         return enabled().orElse(true);
     }
@@ -126,6 +133,10 @@ public interface ArtemisDevServicesBuildTimeConfig {
         return defaultExtraArgs().orElse("--no-autotune --mapped --no-fsync --relax-jolokia");
     }
 
+    default String getJavaArgs() {
+        return javaArgs().orElse("-Dbrokerconfig.maxDiskUsage=-1");
+    }
+
     default boolean isEmpty() {
         return enabled().isEmpty()
                 && port().isEmpty()
@@ -135,6 +146,7 @@ public interface ArtemisDevServicesBuildTimeConfig {
                 && user().isEmpty()
                 && password().isEmpty()
                 && extraArgs().isEmpty()
-                && defaultExtraArgs().isEmpty();
+                && defaultExtraArgs().isEmpty()
+                && getJavaArgs().isEmpty();
     }
 }

--- a/docs/modules/ROOT/pages/includes/attributes.adoc
+++ b/docs/modules/ROOT/pages/includes/attributes.adoc
@@ -1,4 +1,4 @@
-:quarkus-version: 3.31.1
+:quarkus-version: 3.31.3
 :quarkus-artemis-version: 3.12.1
 
 :quarkus-org-url: https://github.com/quarkusio

--- a/docs/modules/ROOT/pages/includes/quarkus-artemis-core.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-artemis-core.adoc
@@ -406,6 +406,34 @@ endif::add-copy-button-to-env-var[]
 |string
 |
 
+a|icon:lock[title=Fixed at build time] [[quarkus-artemis-core_quarkus-artemis-devservices-java-args]] [.property-path]##link:#quarkus-artemis-core_quarkus-artemis-devservices-java-args[`quarkus.artemis.devservices.java-args`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis.devservices.java-args+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`quarkus.artemis."configuration-name".devservices.java-args`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis."configuration-name".devservices.java-args+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+Value to pass into the `JAVA_ARGS_APPEND` environment variable in the container.
+
+Defaults to `-Dbrokerconfig.maxDiskUsage=-1` when not set.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_ARTEMIS_DEVSERVICES_JAVA_ARGS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_ARTEMIS_DEVSERVICES_JAVA_ARGS+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
 a|icon:lock[title=Fixed at build time] [[quarkus-artemis-core_quarkus-artemis-xa-enabled]] [.property-path]##link:#quarkus-artemis-core_quarkus-artemis-xa-enabled[`quarkus.artemis.xa-enabled`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.artemis.xa-enabled+++[]

--- a/docs/modules/ROOT/pages/includes/quarkus-artemis-core_quarkus.artemis.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-artemis-core_quarkus.artemis.adoc
@@ -406,6 +406,34 @@ endif::add-copy-button-to-env-var[]
 |string
 |
 
+a|icon:lock[title=Fixed at build time] [[quarkus-artemis-core_quarkus-artemis-devservices-java-args]] [.property-path]##link:#quarkus-artemis-core_quarkus-artemis-devservices-java-args[`quarkus.artemis.devservices.java-args`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis.devservices.java-args+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`quarkus.artemis."configuration-name".devservices.java-args`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.artemis."configuration-name".devservices.java-args+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+Value to pass into the `JAVA_ARGS_APPEND` environment variable in the container.
+
+Defaults to `-Dbrokerconfig.maxDiskUsage=-1` when not set.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_ARTEMIS_DEVSERVICES_JAVA_ARGS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_ARTEMIS_DEVSERVICES_JAVA_ARGS+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
 a|icon:lock[title=Fixed at build time] [[quarkus-artemis-core_quarkus-artemis-xa-enabled]] [.property-path]##link:#quarkus-artemis-core_quarkus-artemis-xa-enabled[`quarkus.artemis.xa-enabled`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.artemis.xa-enabled+++[]

--- a/docs/modules/ROOT/pages/includes/quarkus-artemis-jms-ra.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-artemis-jms-ra.adoc
@@ -1,0 +1,259 @@
+[.configuration-legend]
+icon:lock[title=Fixed at build time] Configuration property fixed at build time - All other configuration properties are overridable at runtime
+[.configuration-reference.searchable, cols="80,.^10,.^10"]
+|===
+
+h|[.header-title]##Configuration property##
+h|Type
+h|Default
+
+a|icon:lock[title=Fixed at build time] [[quarkus-artemis-jms-ra_quarkus-ironjacamar-devservices-enabled]] [.property-path]##link:#quarkus-artemis-jms-ra_quarkus-ironjacamar-devservices-enabled[`quarkus.ironjacamar.devservices.enabled`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.ironjacamar.devservices.enabled+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Enable or disable Dev Services explicitly. Dev Services are automatically enabled unless `quarkus.ironjacamar.devservices.enabled` is set.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_IRONJACAMAR_DEVSERVICES_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_IRONJACAMAR_DEVSERVICES_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|
+
+a|icon:lock[title=Fixed at build time] [[quarkus-artemis-jms-ra_quarkus-ironjacamar-devservices-reuse]] [.property-path]##link:#quarkus-artemis-jms-ra_quarkus-ironjacamar-devservices-reuse[`quarkus.ironjacamar.devservices.reuse`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.ironjacamar.devservices.reuse+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Allow to reuse Artemis container between dev mode sessions.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_IRONJACAMAR_DEVSERVICES_REUSE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_IRONJACAMAR_DEVSERVICES_REUSE+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
+a|icon:lock[title=Fixed at build time] [[quarkus-artemis-jms-ra_quarkus-ironjacamar-devservices-port]] [.property-path]##link:#quarkus-artemis-jms-ra_quarkus-ironjacamar-devservices-port[`quarkus.ironjacamar.devservices.port`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.ironjacamar.devservices.port+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Optional fixed port the dev service will listen to.
+
+If not defined, the port will be chosen randomly.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_IRONJACAMAR_DEVSERVICES_PORT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_IRONJACAMAR_DEVSERVICES_PORT+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a|icon:lock[title=Fixed at build time] [[quarkus-artemis-jms-ra_quarkus-ironjacamar-devservices-image-name]] [.property-path]##link:#quarkus-artemis-jms-ra_quarkus-ironjacamar-devservices-image-name[`quarkus.ironjacamar.devservices.image-name`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.ironjacamar.devservices.image-name+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The ActiveMQ Artemis container image to use.
+
+Defaults to `quay.io/arkmq-org/activemq-artemis-broker:artemis.2.50.0`
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_IRONJACAMAR_DEVSERVICES_IMAGE_NAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_IRONJACAMAR_DEVSERVICES_IMAGE_NAME+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a|icon:lock[title=Fixed at build time] [[quarkus-artemis-jms-ra_quarkus-ironjacamar-devservices-shared]] [.property-path]##link:#quarkus-artemis-jms-ra_quarkus-ironjacamar-devservices-shared[`quarkus.ironjacamar.devservices.shared`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.ironjacamar.devservices.shared+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Indicates if the ActiveMQ Artemis broker managed by Quarkus Dev Services is shared. When shared, Quarkus looks for running containers using label-based service discovery. If a matching container is found, it is used, and so a second one is not started. Otherwise, Dev Services for ActiveMQ Artemis starts a new container. Is activated by default when not set.
+
+The discovery uses the `quarkus-dev-service-artemis` label. The value is configured using the `service-name` property.
+
+Container sharing is only used in dev mode.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_IRONJACAMAR_DEVSERVICES_SHARED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_IRONJACAMAR_DEVSERVICES_SHARED+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|
+
+a|icon:lock[title=Fixed at build time] [[quarkus-artemis-jms-ra_quarkus-ironjacamar-devservices-service-name]] [.property-path]##link:#quarkus-artemis-jms-ra_quarkus-ironjacamar-devservices-service-name[`quarkus.ironjacamar.devservices.service-name`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.ironjacamar.devservices.service-name+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The value of the `quarkus-dev-service-artemis` label attached to the started container. This property is used when `shared` is set to `true`. It defaults to `artemis` when not set. In this case, before starting a container, Dev Services for ActiveMQ Artemis looks for a container with the `quarkus-dev-service-artemis` label set to the configured value. If found, it will use this container instead of starting a new one. Otherwise it starts a new container with the `quarkus-dev-service-artemis` label set to the specified value.
+
+This property is used when you need multiple shared ActiveMQ Artemis brokers.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_IRONJACAMAR_DEVSERVICES_SERVICE_NAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_IRONJACAMAR_DEVSERVICES_SERVICE_NAME+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a|icon:lock[title=Fixed at build time] [[quarkus-artemis-jms-ra_quarkus-ironjacamar-devservices-user]] [.property-path]##link:#quarkus-artemis-jms-ra_quarkus-ironjacamar-devservices-user[`quarkus.ironjacamar.devservices.user`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.ironjacamar.devservices.user+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+User to start artemis broker. Defaults to `admin` if not set.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_IRONJACAMAR_DEVSERVICES_USER+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_IRONJACAMAR_DEVSERVICES_USER+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a|icon:lock[title=Fixed at build time] [[quarkus-artemis-jms-ra_quarkus-ironjacamar-devservices-password]] [.property-path]##link:#quarkus-artemis-jms-ra_quarkus-ironjacamar-devservices-password[`quarkus.ironjacamar.devservices.password`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.ironjacamar.devservices.password+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Password to start artemis broker. Defaults to `admin` whne not set.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_IRONJACAMAR_DEVSERVICES_PASSWORD+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_IRONJACAMAR_DEVSERVICES_PASSWORD+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a|icon:lock[title=Fixed at build time] [[quarkus-artemis-jms-ra_quarkus-ironjacamar-devservices-extra-args]] [.property-path]##link:#quarkus-artemis-jms-ra_quarkus-ironjacamar-devservices-extra-args[`quarkus.ironjacamar.devservices.extra-args`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.ironjacamar.devservices.extra-args+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The value of the `AMQ_EXTRA_ARGS` environment variable to pass to the container. Defaults to `--no-autotune --mapped --no-fsync` when not set.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_IRONJACAMAR_DEVSERVICES_EXTRA_ARGS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_IRONJACAMAR_DEVSERVICES_EXTRA_ARGS+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a|icon:lock[title=Fixed at build time] [[quarkus-artemis-jms-ra_quarkus-ironjacamar-devservices-java-args]] [.property-path]##link:#quarkus-artemis-jms-ra_quarkus-ironjacamar-devservices-java-args[`quarkus.ironjacamar.devservices.java-args`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.ironjacamar.devservices.java-args+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Value to pass into the `JAVA_ARGS_APPEND` environment variable in the container.
+
+Defaults to `-Dbrokerconfig.maxDiskUsage=-1` when not set.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_IRONJACAMAR_DEVSERVICES_JAVA_ARGS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_IRONJACAMAR_DEVSERVICES_JAVA_ARGS+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a|icon:lock[title=Fixed at build time] [[quarkus-artemis-jms-ra_quarkus-ironjacamar-ra-config-connection-parameters]] [.property-path]##link:#quarkus-artemis-jms-ra_quarkus-ironjacamar-ra-config-connection-parameters[`quarkus.ironjacamar.ra.config.connection-parameters`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.ironjacamar.ra.config.connection-parameters+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`quarkus.ironjacamar."resource-adapter-name".ra.config.connection-parameters`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.ironjacamar."resource-adapter-name".ra.config.connection-parameters+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+The connection string url for this resource adapter
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_IRONJACAMAR_RA_CONFIG_CONNECTION_PARAMETERS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_IRONJACAMAR_RA_CONFIG_CONNECTION_PARAMETERS+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+|===
+

--- a/docs/modules/ROOT/pages/includes/quarkus-artemis-jms-ra_quarkus.ironjacamar.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-artemis-jms-ra_quarkus.ironjacamar.adoc
@@ -1,0 +1,259 @@
+[.configuration-legend]
+icon:lock[title=Fixed at build time] Configuration property fixed at build time - All other configuration properties are overridable at runtime
+[.configuration-reference.searchable, cols="80,.^10,.^10"]
+|===
+
+h|[.header-title]##Configuration property##
+h|Type
+h|Default
+
+a|icon:lock[title=Fixed at build time] [[quarkus-artemis-jms-ra_quarkus-ironjacamar-devservices-enabled]] [.property-path]##link:#quarkus-artemis-jms-ra_quarkus-ironjacamar-devservices-enabled[`quarkus.ironjacamar.devservices.enabled`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.ironjacamar.devservices.enabled+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Enable or disable Dev Services explicitly. Dev Services are automatically enabled unless `quarkus.ironjacamar.devservices.enabled` is set.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_IRONJACAMAR_DEVSERVICES_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_IRONJACAMAR_DEVSERVICES_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|
+
+a|icon:lock[title=Fixed at build time] [[quarkus-artemis-jms-ra_quarkus-ironjacamar-devservices-reuse]] [.property-path]##link:#quarkus-artemis-jms-ra_quarkus-ironjacamar-devservices-reuse[`quarkus.ironjacamar.devservices.reuse`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.ironjacamar.devservices.reuse+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Allow to reuse Artemis container between dev mode sessions.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_IRONJACAMAR_DEVSERVICES_REUSE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_IRONJACAMAR_DEVSERVICES_REUSE+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
+a|icon:lock[title=Fixed at build time] [[quarkus-artemis-jms-ra_quarkus-ironjacamar-devservices-port]] [.property-path]##link:#quarkus-artemis-jms-ra_quarkus-ironjacamar-devservices-port[`quarkus.ironjacamar.devservices.port`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.ironjacamar.devservices.port+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Optional fixed port the dev service will listen to.
+
+If not defined, the port will be chosen randomly.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_IRONJACAMAR_DEVSERVICES_PORT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_IRONJACAMAR_DEVSERVICES_PORT+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a|icon:lock[title=Fixed at build time] [[quarkus-artemis-jms-ra_quarkus-ironjacamar-devservices-image-name]] [.property-path]##link:#quarkus-artemis-jms-ra_quarkus-ironjacamar-devservices-image-name[`quarkus.ironjacamar.devservices.image-name`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.ironjacamar.devservices.image-name+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The ActiveMQ Artemis container image to use.
+
+Defaults to `quay.io/arkmq-org/activemq-artemis-broker:artemis.2.50.0`
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_IRONJACAMAR_DEVSERVICES_IMAGE_NAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_IRONJACAMAR_DEVSERVICES_IMAGE_NAME+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a|icon:lock[title=Fixed at build time] [[quarkus-artemis-jms-ra_quarkus-ironjacamar-devservices-shared]] [.property-path]##link:#quarkus-artemis-jms-ra_quarkus-ironjacamar-devservices-shared[`quarkus.ironjacamar.devservices.shared`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.ironjacamar.devservices.shared+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Indicates if the ActiveMQ Artemis broker managed by Quarkus Dev Services is shared. When shared, Quarkus looks for running containers using label-based service discovery. If a matching container is found, it is used, and so a second one is not started. Otherwise, Dev Services for ActiveMQ Artemis starts a new container. Is activated by default when not set.
+
+The discovery uses the `quarkus-dev-service-artemis` label. The value is configured using the `service-name` property.
+
+Container sharing is only used in dev mode.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_IRONJACAMAR_DEVSERVICES_SHARED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_IRONJACAMAR_DEVSERVICES_SHARED+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|
+
+a|icon:lock[title=Fixed at build time] [[quarkus-artemis-jms-ra_quarkus-ironjacamar-devservices-service-name]] [.property-path]##link:#quarkus-artemis-jms-ra_quarkus-ironjacamar-devservices-service-name[`quarkus.ironjacamar.devservices.service-name`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.ironjacamar.devservices.service-name+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The value of the `quarkus-dev-service-artemis` label attached to the started container. This property is used when `shared` is set to `true`. It defaults to `artemis` when not set. In this case, before starting a container, Dev Services for ActiveMQ Artemis looks for a container with the `quarkus-dev-service-artemis` label set to the configured value. If found, it will use this container instead of starting a new one. Otherwise it starts a new container with the `quarkus-dev-service-artemis` label set to the specified value.
+
+This property is used when you need multiple shared ActiveMQ Artemis brokers.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_IRONJACAMAR_DEVSERVICES_SERVICE_NAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_IRONJACAMAR_DEVSERVICES_SERVICE_NAME+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a|icon:lock[title=Fixed at build time] [[quarkus-artemis-jms-ra_quarkus-ironjacamar-devservices-user]] [.property-path]##link:#quarkus-artemis-jms-ra_quarkus-ironjacamar-devservices-user[`quarkus.ironjacamar.devservices.user`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.ironjacamar.devservices.user+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+User to start artemis broker. Defaults to `admin` if not set.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_IRONJACAMAR_DEVSERVICES_USER+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_IRONJACAMAR_DEVSERVICES_USER+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a|icon:lock[title=Fixed at build time] [[quarkus-artemis-jms-ra_quarkus-ironjacamar-devservices-password]] [.property-path]##link:#quarkus-artemis-jms-ra_quarkus-ironjacamar-devservices-password[`quarkus.ironjacamar.devservices.password`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.ironjacamar.devservices.password+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Password to start artemis broker. Defaults to `admin` whne not set.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_IRONJACAMAR_DEVSERVICES_PASSWORD+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_IRONJACAMAR_DEVSERVICES_PASSWORD+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a|icon:lock[title=Fixed at build time] [[quarkus-artemis-jms-ra_quarkus-ironjacamar-devservices-extra-args]] [.property-path]##link:#quarkus-artemis-jms-ra_quarkus-ironjacamar-devservices-extra-args[`quarkus.ironjacamar.devservices.extra-args`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.ironjacamar.devservices.extra-args+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The value of the `AMQ_EXTRA_ARGS` environment variable to pass to the container. Defaults to `--no-autotune --mapped --no-fsync` when not set.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_IRONJACAMAR_DEVSERVICES_EXTRA_ARGS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_IRONJACAMAR_DEVSERVICES_EXTRA_ARGS+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a|icon:lock[title=Fixed at build time] [[quarkus-artemis-jms-ra_quarkus-ironjacamar-devservices-java-args]] [.property-path]##link:#quarkus-artemis-jms-ra_quarkus-ironjacamar-devservices-java-args[`quarkus.ironjacamar.devservices.java-args`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.ironjacamar.devservices.java-args+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Value to pass into the `JAVA_ARGS_APPEND` environment variable in the container.
+
+Defaults to `-Dbrokerconfig.maxDiskUsage=-1` when not set.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_IRONJACAMAR_DEVSERVICES_JAVA_ARGS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_IRONJACAMAR_DEVSERVICES_JAVA_ARGS+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a|icon:lock[title=Fixed at build time] [[quarkus-artemis-jms-ra_quarkus-ironjacamar-ra-config-connection-parameters]] [.property-path]##link:#quarkus-artemis-jms-ra_quarkus-ironjacamar-ra-config-connection-parameters[`quarkus.ironjacamar.ra.config.connection-parameters`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.ironjacamar.ra.config.connection-parameters+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`quarkus.ironjacamar."resource-adapter-name".ra.config.connection-parameters`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.ironjacamar."resource-adapter-name".ra.config.connection-parameters+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+The connection string url for this resource adapter
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_IRONJACAMAR_RA_CONFIG_CONNECTION_PARAMETERS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_IRONJACAMAR_RA_CONFIG_CONNECTION_PARAMETERS+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+|===
+

--- a/docs/modules/ROOT/pages/quarkus-artemis-ra.adoc
+++ b/docs/modules/ROOT/pages/quarkus-artemis-ra.adoc
@@ -141,6 +141,7 @@ services:
       AMQ_USER: admin
       AMQ_PASSWORD: admin
       AMQ_EXTRA_ARGS: --no-autotune --mapped --no-fsync
+      JAVA_ARGS_APPEND: -Dbrokerconfig.maxDiskUsage=-1
 ----
 
 

--- a/ra/deployment/src/main/java/io/quarkus/artemis/jms/ra/deployment/DevServicesArtemisProcessor.java
+++ b/ra/deployment/src/main/java/io/quarkus/artemis/jms/ra/deployment/DevServicesArtemisProcessor.java
@@ -243,7 +243,8 @@ public class DevServicesArtemisProcessor {
                             config.fixedExposedPort,
                             config.user,
                             config.password,
-                            config.extraArgs);
+                            config.extraArgs,
+                            config.javaArgs);
                     container.withReuse(config.reuse);
 
                     ConfigureUtil.configureSharedNetwork(container, "artemis");
@@ -295,6 +296,8 @@ public class DevServicesArtemisProcessor {
 
         private final String extraArgs;
 
+        private final String javaArgs;
+
         private final boolean reuse;
 
         public ArtemisDevServiceCfg(ArtemisDevServicesBuildTimeConfig devServicesConfig,
@@ -307,6 +310,7 @@ public class DevServicesArtemisProcessor {
             this.user = devServicesConfig.getUser();
             this.password = devServicesConfig.getPassword();
             this.extraArgs = devServicesConfig.getExtraArgs();
+            this.javaArgs = devServicesConfig.getJavaArgs();
             this.reuse = devServicesConfig.reuse();
         }
 
@@ -337,7 +341,7 @@ public class DevServicesArtemisProcessor {
         private final int port;
 
         private ArtemisContainer(DockerImageName dockerImageName, int fixedExposedPort, String user, String password,
-                String extra) {
+                String extra, String javaArgs) {
             super(dockerImageName);
             this.port = fixedExposedPort;
             withNetwork(Network.SHARED)
@@ -345,6 +349,7 @@ public class DevServicesArtemisProcessor {
                     .withEnv("AMQ_USER", user)
                     .withEnv("AMQ_PASSWORD", password)
                     .withEnv("AMQ_EXTRA_ARGS", extra)
+                    .withEnv("JAVA_ARGS_APPEND", javaArgs)
                     .waitingFor(Wait.forLogMessage(".*AMQ241004.*", 1)); // Artemis console available.
         }
 

--- a/ra/runtime/src/main/java/io/quarkus/artemis/jms/ra/runtime/ArtemisDevServicesBuildTimeConfig.java
+++ b/ra/runtime/src/main/java/io/quarkus/artemis/jms/ra/runtime/ArtemisDevServicesBuildTimeConfig.java
@@ -78,6 +78,13 @@ public interface ArtemisDevServicesBuildTimeConfig {
      */
     Optional<String> extraArgs();
 
+    /**
+     * Value to pass into the {@code JAVA_ARGS_APPEND} environment variable in the container.
+     * <p>
+     * Defaults to {@code -Dbrokerconfig.maxDiskUsage=-1} when not set.
+     */
+    Optional<String> javaArgs();
+
     default int getPort() {
         return port().orElse(0);
     }
@@ -106,4 +113,7 @@ public interface ArtemisDevServicesBuildTimeConfig {
         return extraArgs().orElse("--no-autotune --mapped --no-fsync");
     }
 
+    default String getJavaArgs() {
+        return javaArgs().orElse("-Dbrokerconfig.maxDiskUsage=-1");
+    }
 }


### PR DESCRIPTION
expose jvm args to devservice config. Default value is -Dbrokerconfig.maxDiskUsage=-1 to disable max disk usage. My CI fail to build because Artemis block the broker when disk usage is higher than 90%