### PR TITLE
Use setParent instead of addLink for JMS consumer trace context propagation

### DIFF
--- a/integration-tests/jms/with-opentelemetry/src/test/java/io/quarkus/it/artemis/jms/opentelemetry/BaseOpenTelemetryTest.java
+++ b/integration-tests/jms/with-opentelemetry/src/test/java/io/quarkus/it/artemis/jms/opentelemetry/BaseOpenTelemetryTest.java
@@ -158,14 +158,10 @@ abstract public class BaseOpenTelemetryTest {
                 .findFirst()
                 .orElseThrow(() -> new AssertionError("No consumer span found"));
 
-        // Verify the consumer span has a link back to the producer span's context
-        assertThat("Consumer span should have at least one link for trace context propagation",
-                consumerSpan.links, is(not(empty())));
-
-        boolean hasLinkToProducer = consumerSpan.links.stream()
-                .anyMatch(link -> link.traceId.equals(producerSpan.traceId)
-                        && link.spanId.equals(producerSpan.spanId));
-        assertThat("Consumer span should link to the producer span", hasLinkToProducer, is(true));
+        // Verify the consumer span shares the same traceId as the producer span
+        // (parent-child relationship via trace context propagation through JMS message properties)
+        assertThat("Consumer span should have the same traceId as the producer span",
+                consumerSpan.traceId, is(equalTo(producerSpan.traceId)));
     }
 
     @Test
@@ -224,14 +220,10 @@ abstract public class BaseOpenTelemetryTest {
         assertThat("Consumer should have messaging.destination.name=test-jms-otel",
                 consumerSpan.attributes.get("messaging.destination.name"), is(equalTo("test-jms-otel")));
 
-        // Verify context propagation through the classic API path
-        assertThat("Consumer span should have links for trace context propagation",
-                consumerSpan.links, is(not(empty())));
-
-        boolean hasLinkToProducer = consumerSpan.links.stream()
-                .anyMatch(link -> link.traceId.equals(producerSpan.traceId)
-                        && link.spanId.equals(producerSpan.spanId));
-        assertThat("Consumer span should link to the producer span", hasLinkToProducer, is(true));
+        // Verify the consumer span shares the same traceId as the producer span
+        // (parent-child relationship via trace context propagation through JMS message properties)
+        assertThat("Consumer span should have the same traceId as the producer span",
+                consumerSpan.traceId, is(equalTo(producerSpan.traceId)));
     }
 
     @Test

--- a/jms/runtime/src/main/java/io/quarkus/artemis/jms/runtime/tracing/TracingJMSConsumer.java
+++ b/jms/runtime/src/main/java/io/quarkus/artemis/jms/runtime/tracing/TracingJMSConsumer.java
@@ -101,18 +101,15 @@ class TracingJMSConsumer implements JMSConsumer {
     private void createReceiveSpan(Message message) {
         String spanName = JmsSpanAttributes.generateSpanName(destination, "receive");
 
-        // Extract context from message to create a link
+        // Extract context from message to establish parent-child relationship
         Context extractedContext = contextPropagator.extractContext(message);
 
         SpanBuilder spanBuilder = tracer.spanBuilder(spanName)
                 .setSpanKind(SpanKind.CONSUMER);
 
-        // Use link instead of parent-child relationship as per OTel messaging spec
+        // Set extracted context as parent so the consumer span shares the same traceId
         if (extractedContext != null) {
-            Span parentSpan = Span.fromContext(extractedContext);
-            if (parentSpan != null && parentSpan.getSpanContext().isValid()) {
-                spanBuilder.addLink(parentSpan.getSpanContext());
-            }
+            spanBuilder.setParent(extractedContext);
         }
 
         Span span = spanBuilder.startSpan();
@@ -172,18 +169,15 @@ class TracingJMSConsumer implements JMSConsumer {
         public void onMessage(Message message) {
             String spanName = JmsSpanAttributes.generateSpanName(destination, "receive");
 
-            // Extract context from message to create a link
+            // Extract context from message to establish parent-child relationship
             Context extractedContext = contextPropagator.extractContext(message);
 
             SpanBuilder spanBuilder = tracer.spanBuilder(spanName)
                     .setSpanKind(SpanKind.CONSUMER);
 
-            // Use link instead of parent-child relationship
+            // Set extracted context as parent so the consumer span shares the same traceId
             if (extractedContext != null) {
-                Span parentSpan = Span.fromContext(extractedContext);
-                if (parentSpan != null && parentSpan.getSpanContext().isValid()) {
-                    spanBuilder.addLink(parentSpan.getSpanContext());
-                }
+                spanBuilder.setParent(extractedContext);
             }
 
             Span span = spanBuilder.startSpan();

--- a/jms/runtime/src/main/java/io/quarkus/artemis/jms/runtime/tracing/TracingMessageConsumer.java
+++ b/jms/runtime/src/main/java/io/quarkus/artemis/jms/runtime/tracing/TracingMessageConsumer.java
@@ -58,19 +58,15 @@ class TracingMessageConsumer implements MessageConsumer {
     private void createReceiveSpan(Message message) {
         String spanName = JmsSpanAttributes.generateSpanName(destination, "receive");
 
-        // Extract context from message to create a link
+        // Extract context from message to establish parent-child relationship
         Context extractedContext = contextPropagator.extractContext(message);
 
         SpanBuilder spanBuilder = tracer.spanBuilder(spanName)
                 .setSpanKind(SpanKind.CONSUMER);
 
-        // Use link instead of parent-child relationship as per OTel messaging spec
-        // This is because we cannot guarantee there's no ambiguity on parent spans
+        // Set extracted context as parent so the consumer span shares the same traceId
         if (extractedContext != null) {
-            Span parentSpan = Span.fromContext(extractedContext);
-            if (parentSpan != null && parentSpan.getSpanContext().isValid()) {
-                spanBuilder.addLink(parentSpan.getSpanContext());
-            }
+            spanBuilder.setParent(extractedContext);
         }
 
         Span span = spanBuilder.startSpan();
@@ -137,18 +133,15 @@ class TracingMessageConsumer implements MessageConsumer {
         public void onMessage(Message message) {
             String spanName = JmsSpanAttributes.generateSpanName(destination, "receive");
 
-            // Extract context from message to create a link
+            // Extract context from message to establish parent-child relationship
             Context extractedContext = contextPropagator.extractContext(message);
 
             SpanBuilder spanBuilder = tracer.spanBuilder(spanName)
                     .setSpanKind(SpanKind.CONSUMER);
 
-            // Use link instead of parent-child relationship
+            // Set extracted context as parent so the consumer span shares the same traceId
             if (extractedContext != null) {
-                Span parentSpan = Span.fromContext(extractedContext);
-                if (parentSpan != null && parentSpan.getSpanContext().isValid()) {
-                    spanBuilder.addLink(parentSpan.getSpanContext());
-                }
+                spanBuilder.setParent(extractedContext);
             }
 
             Span span = spanBuilder.startSpan();


### PR DESCRIPTION
## Summary

- Changed JMS consumer span creation from `addLink()` to `setParent(extractedContext)` in `TracingMessageConsumer` and `TracingJMSConsumer`
- This allows JMS consumer spans to share the same traceId as the producer span, enabling end-to-end trace visibility
- Updated integration tests to assert same traceId instead of checking for links

## Context

When using `addLink()`, JMS consumer spans start a new trace with a link back to the producer span. While valid per OTel messaging conventions, this breaks end-to-end trace visibility in observability tools (Jaeger, Zipkin, etc.).

Using `setParent()` creates a parent-child relationship where the consumer span inherits the producer's traceId, giving a single connected trace from HTTP → EventBus → JMS producer → JMS consumer.

**Note**: This is a behavioral change worth discussing with the community. The OTel messaging semantic conventions allow both approaches:
- `setParent` for single-message receive (clear 1:1 causal relationship)
- `addLink` for batch receive or fan-in/fan-out patterns

This PR uses `setParent` for simpler end-to-end tracing. If the community prefers `addLink`, we can revert this and keep the traces separate.

Related issues:
- https://github.com/quarkiverse/quarkus-artemis/issues/1063
- https://github.com/quarkusio/quarkus/issues/53054

## Test plan

- [x] All 6 integration tests in `integration-tests/jms/with-opentelemetry` pass
- [x] Verified with reproducer project that HTTP → JMS producer → JMS consumer all share same traceId

🤖 Generated with [Claude Code](https://claude.com/claude-code)