### PR TITLE
Do not use quarkus:go-offline for extensions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,6 +111,7 @@ jobs:
             --batch-mode \
             --define maven.buildNumber.skip \
             --projects integration-tests \
+            --also-make-dependents \
             quarkus:go-offline
 
   build-and-test-jvm:


### PR DESCRIPTION
See discussion in https://github.com/quarkusio/quarkus/issues/52695#issuecomment-4135523885. This should unstick https://github.com/quarkiverse/quarkus-artemis/pull/1047. 

The current build runs `quarkus:go-offline` against extensions. It used to work, but it's not really a supported thing. The aim of this PR is to not run that goal against the extensions, only the test applications. Sadly, it's hard to test, because it changes the workflows.

The CI workflow has a "Populate Maven Cache" step that runs quarkus:go-offline to pre-download all dependencies. Previously it ran on every module in the reactor, including the extension modules (quarkus-artemis-core, quarkus-artemis-jms-ra, etc.). `quarkus:go-offline` resolves the full Quarkus app model, which is only meaningful fo  application modules, not extensions. Since `quarkus-artemis-jms-ra` directly depends on quarkus-devservices, the resolver treats it as a deployment injection point and fails validation because quarkus-devservices-deployment doesn't depend on quarkus-devservices runtime (which is by design, but upsets validation code).

  The fix splits the cache population into two commands:
  1. go-offline-maven-plugin:resolve-dependencies on all modules — downloads regular Maven dependencies
  2. quarkus:go-offline only on integration-tests — resolves Quarkus app model dependencies only for the actual application modules, where quarkus-devservices is transitive (not direct) and won't trigger the validation
