### PR TITLE
Fix NPE in ArtemisResourceAdapterFactory when connection-parameters is not set

### DIFF
--- a/ra/runtime/pom.xml
+++ b/ra/runtime/pom.xml
@@ -68,5 +68,10 @@
             <artifactId>quarkus-smallrye-health</artifactId>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/ra/runtime/src/main/java/io/quarkus/artemis/jms/ra/ArtemisResourceAdapterFactory.java
+++ b/ra/runtime/src/main/java/io/quarkus/artemis/jms/ra/ArtemisResourceAdapterFactory.java
@@ -95,6 +95,9 @@ public class ArtemisResourceAdapterFactory implements ResourceAdapterFactory {
     }
 
     private static int count(String text, String find) {
+        if (text == null) {
+            return 0;
+        }
         int count = 0;
         final int length = find.length();
         for (int index = 0; (index = text.indexOf(find, index)) != -1; index += length) {

--- a/ra/runtime/src/test/java/io/quarkus/artemis/jms/ra/ArtemisResourceAdapterFactoryTest.java
+++ b/ra/runtime/src/test/java/io/quarkus/artemis/jms/ra/ArtemisResourceAdapterFactoryTest.java
@@ -1,0 +1,33 @@
+package io.quarkus.artemis.jms.ra;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+class ArtemisResourceAdapterFactoryTest {
+
+    @Test
+    void createResourceAdapterWithNullConnectionParameters() {
+        ArtemisResourceAdapterFactory factory = new ArtemisResourceAdapterFactory();
+        assertDoesNotThrow(() -> factory.createResourceAdapter("test", Map.of()));
+    }
+
+    @Test
+    void createResourceAdapterWithConnectionParameters() {
+        ArtemisResourceAdapterFactory factory = new ArtemisResourceAdapterFactory();
+        var adapter = factory.createResourceAdapter("test",
+                Map.of("connection-parameters", "host=localhost;port=61616"));
+        assertNotNull(adapter);
+    }
+
+    @Test
+    void createResourceAdapterWithMultipleHosts() {
+        ArtemisResourceAdapterFactory factory = new ArtemisResourceAdapterFactory();
+        var adapter = factory.createResourceAdapter("test",
+                Map.of("connection-parameters", "host=host1;port=61616,host=host2;port=61617"));
+        assertNotNull(adapter);
+    }
+}


### PR DESCRIPTION
The count() method did not handle a null text argument, causing a `NullPointerException` when the `connection-parameters` config key is absent. Return 0 for `null` input so a single connector is used by default.
