### PR TITLE
Dev Service Artemis JMS Resource Adapter links

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/artemis/core/deployment/DevServicesArtemisProcessor.java
+++ b/core/deployment/src/main/java/io/quarkus/artemis/core/deployment/DevServicesArtemisProcessor.java
@@ -47,7 +47,7 @@ public class DevServicesArtemisProcessor {
      */
     static final String DEV_SERVICE_LABEL = "quarkus-dev-service-artemis";
     static final int ARTEMIS_PORT = 61616;
-    static final int ARTEMIS_WEB_UI_PORT = 8161;
+    public static final int ARTEMIS_WEB_UI_PORT = 8161;
 
     private static final ContainerLocator artemisContainerLocator = locateContainerWithLabels(ARTEMIS_PORT,
             DEV_SERVICE_LABEL);
@@ -196,7 +196,7 @@ public class DevServicesArtemisProcessor {
         return getArtemisPropertyBase(name) + "url";
     }
 
-    private static String getWebUiUrlPropertyName(String name) {
+    public static String getWebUiUrlPropertyName(String name) {
         return getArtemisPropertyBase(name) + "web-ui-url";
     }
 

--- a/docs/modules/ROOT/pages/quarkus-artemis-ra.adoc
+++ b/docs/modules/ROOT/pages/quarkus-artemis-ra.adoc
@@ -40,13 +40,13 @@ it is recommended to add the following BOM to your project, *below the Quarkus B
 </dependencyManagement>
 ----
 
-Once the BOM is added, simply add the `io.quarkiverse.artemis:quarkus-artemis-ra` extension:
+Once the BOM is added, simply add the `io.quarkiverse.artemis:quarkus-artemis-jms-ra` extension:
 
 [source,xml,subs=attributes+]
 ----
 <dependency>
     <groupId>io.quarkiverse.artemis</groupId>
-    <artifactId>quarkus-artemis-ra</artifactId>
+    <artifactId>quarkus-artemis-jms-ra</artifactId>
 </dependency>
 ----
 
@@ -140,7 +140,7 @@ services:
     environment:
       AMQ_USER: admin
       AMQ_PASSWORD: admin
-      AMQ_EXTRA_ARGS: --no-autotune --mapped --no-fsync
+      AMQ_EXTRA_ARGS: --no-autotune --mapped --no-fsync --relax-jolokia
 ----
 
 

--- a/ra/deployment/src/main/java/io/quarkus/artemis/jms/ra/deployment/DevServicesArtemisProcessor.java
+++ b/ra/deployment/src/main/java/io/quarkus/artemis/jms/ra/deployment/DevServicesArtemisProcessor.java
@@ -1,5 +1,6 @@
 package io.quarkus.artemis.jms.ra.deployment;
 
+import static io.quarkus.artemis.core.deployment.DevServicesArtemisProcessor.*;
 import static io.quarkus.devservices.common.ConfigureUtil.configureSharedServiceLabel;
 import static io.quarkus.devservices.common.ContainerLocator.locateContainerWithLabels;
 
@@ -22,6 +23,8 @@ import io.quarkus.deployment.dev.devservices.DevServicesConfig;
 import io.quarkus.devservices.common.ComposeLocator;
 import io.quarkus.devservices.common.ConfigureUtil;
 import io.quarkus.devservices.common.ContainerLocator;
+import io.quarkus.devui.spi.page.CardPageBuildItem;
+import io.quarkus.devui.spi.page.Page;
 import io.quarkus.runtime.LaunchMode;
 import io.quarkus.runtime.configuration.ConfigUtils;
 
@@ -58,12 +61,16 @@ public class DevServicesArtemisProcessor {
             ShadowIronJacamarRuntimeConfig runtimeConfig,
             ArtemisDevServicesBuildTimeConfig devServicesBuildTimeConfig,
             BuildProducer<DevServicesResultBuildItem> devServicesResult,
-            DevServicesConfig devServicesConfig) {
+            DevServicesConfig devServicesConfig,
+            BuildProducer<CardPageBuildItem> cardPageProducer) {
+
+        CardPageBuildItem cardPage = new CardPageBuildItem();
 
         for (String name : buildConfig.resourceAdapters().keySet()) {
             boolean isUrlEmpty = runtimeConfig.resourceAdapters().get(name).ra().config().connectionParameters().isEmpty();
             boolean useSharedNetwork = DevServicesSharedNetworkBuildItem.isSharedNetworkRequired(devServicesConfig,
                     devServicesSharedNetworkBuildItem);
+            String feature = "ActiveMQ-Artemis " + name;
 
             ArtemisDevServiceCfg configuration = getConfiguration(devServicesBuildTimeConfig, name, isUrlEmpty);
             if (configuration == null || !configuration.devServicesEnabled) {
@@ -76,6 +83,8 @@ public class DevServicesArtemisProcessor {
             }
 
             String urlPropertyName = getUrlPropertyName(name);
+            String webUiUrlPropertyName = getWebUiUrlPropertyName(name);
+
             if (ConfigUtils.isPropertyPresent(urlPropertyName)) {
                 LOGGER.debugf(
                         "Not starting dev services for ActiveMQ Artemis and configuration %s, the quarkus.ironjacamar.ra.config.connection-parameters is configured.",
@@ -89,7 +98,7 @@ public class DevServicesArtemisProcessor {
                 continue;
             }
 
-            DevServicesResultBuildItem discovered = discoverRunningService(composeProjectBuildItem, name, configuration,
+            DevServicesResultBuildItem discovered = discoverRunningService(composeProjectBuildItem, feature, configuration,
                     urlPropertyName, launchMode.getLaunchMode(), useSharedNetwork);
             if (discovered != null) {
                 devServicesResult.produce(discovered);
@@ -98,7 +107,7 @@ public class DevServicesArtemisProcessor {
 
             Optional<Duration> timeout = devServicesConfig.timeout();
             devServicesResult.produce(DevServicesResultBuildItem.<ArtemisContainer> owned()
-                    .name("ActiveMQ-Artemis " + name)
+                    .feature(feature)
                     .serviceName(configuration.serviceName)
                     .serviceConfig(configuration)
                     .startable(() -> {
@@ -107,6 +116,7 @@ public class DevServicesArtemisProcessor {
                                 configuration.fixedExposedPort,
                                 composeProjectBuildItem.getDefaultNetworkId(),
                                 useSharedNetwork,
+                                configuration.webUiPort,
                                 configuration.user,
                                 configuration.password,
                                 configuration.extraArgs);
@@ -114,16 +124,28 @@ public class DevServicesArtemisProcessor {
                         return container.withReuse(configuration.reuse)
                                 .withSharedServiceLabel(launchMode.getLaunchMode(), configuration.serviceName);
                     })
-                    .configProvider(Map.of(urlPropertyName,
-                            container -> String.format("host=%s;port=%d;protocols=CORE",
-                                    container.getHost(), container.getPort())))
+                    .configProvider(Map.of(
+                            urlPropertyName,
+                            container -> String.format("host=%s;port=%d;protocols=CORE", container.getHost(),
+                                    container.getPort()),
+                            webUiUrlPropertyName,
+                            container -> String.format("http://%s:%d", container.getHost(),
+                                    container.getMappedPort(ARTEMIS_WEB_UI_PORT))))
                     .build());
+
+            cardPage.addPage(Page.externalPageBuilder(name + " web UI")
+                    .dynamicUrlJsonRPCMethodName("devui-dev-services:devServicesConfig",
+                            Map.of("name", feature, "configKey", webUiUrlPropertyName))
+                    .doNotEmbed()
+                    .isHtmlContent()
+                    .icon("font-awesome-solid:binoculars"));
         }
+        cardPageProducer.produce(cardPage);
     }
 
     private DevServicesResultBuildItem discoverRunningService(
             DevServicesComposeProjectBuildItem composeProjectBuildItem,
-            String name,
+            String feature,
             ArtemisDevServiceCfg config,
             String urlPropertyName,
             LaunchMode launchMode,
@@ -133,7 +155,7 @@ public class DevServicesArtemisProcessor {
                         List.of(config.imageName, "artemis"),
                         ARTEMIS_PORT, launchMode, useSharedNetwork))
                 .map(containerAddress -> DevServicesResultBuildItem.discovered()
-                        .name("ActiveMQ-Artemis " + name)
+                        .feature(feature)
                         .containerId(containerAddress.getId())
                         .config(Map.of(urlPropertyName,
                                 String.format("host=%s;port=%d;protocols=CORE",
@@ -162,6 +184,7 @@ public class DevServicesArtemisProcessor {
         private final boolean devServicesEnabled;
         private final String imageName;
         private final Integer fixedExposedPort;
+        private final Integer webUiPort;
         private final boolean shared;
         private final String serviceName;
         private final String user;
@@ -174,6 +197,7 @@ public class DevServicesArtemisProcessor {
             this.devServicesEnabled = devServicesConfig.enabled().orElse(isUrlEmpty);
             this.imageName = devServicesConfig.getImageName();
             this.fixedExposedPort = devServicesConfig.getPort();
+            this.webUiPort = devServicesConfig.getWebUiPort();
             this.shared = devServicesConfig.isShared();
             this.serviceName = devServicesConfig.getServiceName() + "-" + name;
             this.user = devServicesConfig.getUser();
@@ -210,14 +234,18 @@ public class DevServicesArtemisProcessor {
         private final int fixedExposedPort;
         private final boolean useSharedNetwork;
         private final String hostName;
+        private final int webUiPort;
 
         private ArtemisContainer(DockerImageName dockerImageName, int fixedExposedPort, String defaultNetworkId,
-                boolean useSharedNetwork, String user, String password, String extra) {
+                boolean useSharedNetwork, int webUiPort, String user, String password, String extra) {
             super(dockerImageName);
             this.fixedExposedPort = fixedExposedPort;
             this.useSharedNetwork = useSharedNetwork;
             this.hostName = ConfigureUtil.configureNetwork(this, defaultNetworkId, useSharedNetwork, "artemis");
-            withEnv("AMQ_USER", user)
+            this.webUiPort = webUiPort;
+
+            withExposedPorts(ARTEMIS_PORT, ARTEMIS_WEB_UI_PORT)
+                    .withEnv("AMQ_USER", user)
                     .withEnv("AMQ_PASSWORD", password)
                     .withEnv("AMQ_EXTRA_ARGS", extra)
                     .waitingFor(Wait.forLogMessage(".*AMQ241004.*", 1)); // Artemis console available.
@@ -237,6 +265,9 @@ public class DevServicesArtemisProcessor {
                 addFixedExposedPort(fixedExposedPort, ARTEMIS_PORT);
             } else {
                 addExposedPort(ARTEMIS_PORT);
+            }
+            if (webUiPort > 0) {
+                addFixedExposedPort(webUiPort, ARTEMIS_WEB_UI_PORT);
             }
         }
 

--- a/ra/runtime/src/main/java/io/quarkus/artemis/jms/ra/runtime/ArtemisDevServicesBuildTimeConfig.java
+++ b/ra/runtime/src/main/java/io/quarkus/artemis/jms/ra/runtime/ArtemisDevServicesBuildTimeConfig.java
@@ -30,6 +30,13 @@ public interface ArtemisDevServicesBuildTimeConfig {
     Optional<Integer> port();
 
     /**
+     * Optional fixed port the Artemis Web-Ui will be exposed at.
+     * <p>
+     * If not defined, the Artemis Web-Ui port will be chosen randomly.
+     */
+    Optional<Integer> webUiPort();
+
+    /**
      * The ActiveMQ Artemis container image to use.
      * <p>
      * Defaults to {@code quay.io/arkmq-org/activemq-artemis-broker:artemis.2.52.0}
@@ -74,12 +81,16 @@ public interface ArtemisDevServicesBuildTimeConfig {
 
     /**
      * The value of the {@code AMQ_EXTRA_ARGS} environment variable to pass to the container. Defaults to
-     * {@code --no-autotune --mapped --no-fsync} when not set.
+     * {@code --no-autotune --mapped --no-fsync --relax-jolokia} when not set.
      */
     Optional<String> extraArgs();
 
     default int getPort() {
         return port().orElse(0);
+    }
+
+    default int getWebUiPort() {
+        return webUiPort().orElse(0);
     }
 
     default String getImageName() {
@@ -103,7 +114,7 @@ public interface ArtemisDevServicesBuildTimeConfig {
     }
 
     default String getExtraArgs() {
-        return extraArgs().orElse("--no-autotune --mapped --no-fsync");
+        return extraArgs().orElse("--no-autotune --mapped --no-fsync --relax-jolokia");
     }
 
 }


### PR DESCRIPTION
this PR adds the links to the RA dev service, and corrects the 2 calls to deprecated `name(String)`  method.
given the layout, and the size of the property names (e.g. `quarkus.ironjacamar.ra.config.connection-parameters`), this looks a bit ugly. the property name has some value, so I am not sure whether or not we want to keep it. your opinion?
the url for the console ui works fine. but the property value for the broker connection parameters `host=localhost;port=56482;protocols=CORE` is rendered as
`http://localhost:8080/q/dev-ui/host=localhost;port=56482;protocols=CORE`, which is wrong.
I think this is caused by the connection parameters not having an `http` scheme (well, it has no scheme altogether).
I am not sure we can do better. any idea @phillip-kruger ?
other than that, the change works fine. I tested it on an app with 2 ra:
```
quarkus.ironjacamar.ra.kind=artemis
quarkus.ironjacamar.foo.ra.kind=artemis
```
```
        <dependency>
            <groupId>io.quarkiverse.artemis</groupId>
            <artifactId>quarkus-artemis-jms-ra</artifactId>
        </dependency>
```
I also corrected typos in the documentation.