### PR TITLE
docs: escape artemis-version attribute to fix Antora build warnings

### DIFF
--- a/docs/modules/ROOT/pages/quarkus-artemis-jms.adoc
+++ b/docs/modules/ROOT/pages/quarkus-artemis-jms.adoc
@@ -206,7 +206,7 @@ it is recommended to add the following BOM to your project, *below the Quarkus B
         <dependency>
             <groupId>org.apache.activemq</groupId>
             <artifactId>artemis-bom</artifactId>
-            <version>${artemis-version}</version>
+            <version>$\{artemis-version}</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>

--- a/docs/modules/ROOT/pages/quarkus-artemis-ra.adoc
+++ b/docs/modules/ROOT/pages/quarkus-artemis-ra.adoc
@@ -18,7 +18,7 @@ it is recommended to add the following BOM to your project, *below the Quarkus B
         <dependency>
             <groupId>org.apache.activemq</groupId>
             <artifactId>artemis-bom</artifactId>
-            <version>${artemis-version}</version>
+            <version>$\{artemis-version}</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>


### PR DESCRIPTION
This fixes the build warnings in quarkiverse-docs