### PR TITLE
Fix OTel wrapper breaking Pooled JMS initialization

### DIFF
--- a/jms/deployment/src/main/java/io/quarkus/artemis/jms/deployment/ArtemisJmsProcessor.java
+++ b/jms/deployment/src/main/java/io/quarkus/artemis/jms/deployment/ArtemisJmsProcessor.java
@@ -94,15 +94,17 @@ public class ArtemisJmsProcessor {
             List<ConnectionFactoryWrapperBuildItem> localWrappers) {
         Function<ConnectionFactory, Object> wrapper = recorder.getDefaultWrapper();
 
-        // First apply the external wrapper (e.g., from quarkus-pooled-jms) if present
-        if (externalWrapper.isPresent()) {
-            wrapper = externalWrapper.get().getWrapper();
-        }
-
-        // Then compose all local wrappers (e.g., OpenTelemetry) on top
+        // First compose all local wrappers (e.g., OpenTelemetry) so they wrap the raw ConnectionFactory
         // Use the recorder's composeWrappers method to avoid lambda serialization issues
         for (ConnectionFactoryWrapperBuildItem localWrapper : localWrappers) {
             wrapper = recorder.composeWrappers(wrapper, localWrapper.getWrapper());
+        }
+
+        // Then apply the external wrapper (e.g., from quarkus-pooled-jms) on top.
+        // This ensures the CDI bean type is preserved (e.g., DelegatingJmsPoolConnectionFactory)
+        // so that downstream initializers can detect it via instanceof checks.
+        if (externalWrapper.isPresent()) {
+            wrapper = recorder.composeWrappers(wrapper, externalWrapper.get().getWrapper());
         }
 
         return wrapper;

--- a/jms/runtime/src/main/java/io/quarkus/artemis/jms/runtime/tracing/TracingConnectionFactory.java
+++ b/jms/runtime/src/main/java/io/quarkus/artemis/jms/runtime/tracing/TracingConnectionFactory.java
@@ -30,6 +30,10 @@ public class TracingConnectionFactory implements ConnectionFactory, XAConnection
         this.openTelemetrySupplier = openTelemetrySupplier;
     }
 
+    public ConnectionFactory getDelegate() {
+        return delegate;
+    }
+
     private void ensureInitialized() {
         if (tracer == null) {
             synchronized (this) {


### PR DESCRIPTION
## Summary
- Reverse the `ConnectionFactory` wrapper composition order in `ArtemisJmsProcessor.getWrapper()` so that local wrappers (e.g., OpenTelemetry) wrap the raw `ConnectionFactory` first, and the external wrapper (e.g., quarkus-pooled-jms) wraps on top
- This preserves the CDI bean type (e.g., `DelegatingJmsPoolConnectionFactory`) so that `PooledJmsConnectionFactoryInitializer` can detect it via `instanceof` checks
- Add `getDelegate()` to `TracingConnectionFactory` to allow unwrapping to the underlying `ConnectionFactory`

## Problem
When both OTel and quarkus-pooled-jms are active, the previous composition order produced:
```
TracingConnectionFactory(DelegatingJmsPoolConnectionFactory(rawCF))
```
The CDI bean was `TracingConnectionFactory`, so the pooled-jms initializer's `instanceof DelegatingJmsPoolConnectionFactory` check failed, and the pool was never initialized.

## Fix
The new order produces:
```
DelegatingJmsPoolConnectionFactory(TracingConnectionFactory(rawCF))
```
The CDI bean is now `DelegatingJmsPoolConnectionFactory`, the initializer finds it correctly, and tracing still wraps connections inside the pool.

Fixes #1138

## Test plan
- [x] OTel integration tests pass (6/6)
- [ ] Verify with quarkus-pooled-jms + OTel together

🤖 Generated with [Claude Code](https://claude.com/claude-code)