### PR TITLE
General housekeeping

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/artemis/core/deployment/health/ArtemisHealthProcessor.java
+++ b/core/deployment/src/main/java/io/quarkus/artemis/core/deployment/health/ArtemisHealthProcessor.java
@@ -6,7 +6,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Singleton;
 
 import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
 import io.quarkus.artemis.core.deployment.ArtemisBootstrappedBuildItem;
@@ -47,7 +47,7 @@ public class ArtemisHealthProcessor {
         syntheticBeanProducer.produce(SyntheticBeanBuildItem
                 .configure(ArtemisHealthSupport.class)
                 .supplier(recorder.getArtemisHealthSupportBuilder(names))
-                .scope(ApplicationScoped.class)
+                .scope(Singleton.class)
                 .defaultBean()
                 .done());
         return new ArtemisHealthSupportBuildItem();

--- a/core/runtime/src/main/java/io/quarkus/artemis/core/runtime/health/ArtemisHealthSupport.java
+++ b/core/runtime/src/main/java/io/quarkus/artemis/core/runtime/health/ArtemisHealthSupport.java
@@ -2,14 +2,5 @@ package io.quarkus.artemis.core.runtime.health;
 
 import java.util.Set;
 
-public class ArtemisHealthSupport {
-    private final Set<String> configuredNames;
-
-    public ArtemisHealthSupport(Set<String> configuredNames) {
-        this.configuredNames = configuredNames;
-    }
-
-    public Set<String> getConfiguredNames() {
-        return configuredNames;
-    }
+public record ArtemisHealthSupport(Set<String> configuredNames) {
 }

--- a/core/runtime/src/main/java/io/quarkus/artemis/core/runtime/health/ServerLocatorHealthCheck.java
+++ b/core/runtime/src/main/java/io/quarkus/artemis/core/runtime/health/ServerLocatorHealthCheck.java
@@ -35,7 +35,7 @@ public class ServerLocatorHealthCheck implements HealthCheck {
             @Any Instance<ServerLocator> serverLocators) {
         this.runtimeConfigs = runtimeConfigs;
         this.serverLocators = serverLocators;
-        serverLocatorNames = support.getConfiguredNames().stream()
+        serverLocatorNames = support.configuredNames().stream()
                 .filter(name -> runtimeConfigs.configs().get(name).isHealthInclude())
                 .collect(Collectors.toCollection(HashSet::new));
         serverLocatorNames.addAll(ArtemisUtil.getExternalNames(ServerLocator.class, runtimeConfigs, buildTimeConfigs));

--- a/integration-tests/jms/with-opentelemetry/src/main/java/io/quarkus/it/artemis/jms/opentelemetry/ArtemisEndpoint.java
+++ b/integration-tests/jms/with-opentelemetry/src/main/java/io/quarkus/it/artemis/jms/opentelemetry/ArtemisEndpoint.java
@@ -19,7 +19,6 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 
-import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
 import io.quarkus.it.artemis.jms.common.ArtemisJmsConsumerManager;
 import io.quarkus.it.artemis.jms.common.ArtemisJmsProducerManager;
@@ -138,24 +137,24 @@ public class ArtemisEndpoint {
                 .map(span -> {
                     Map<String, String> attrs = span.getAttributes().asMap().entrySet().stream()
                             .collect(Collectors.toMap(
-                                    e -> ((AttributeKey<?>) e.getKey()).getKey(),
+                                    e -> e.getKey().getKey(),
                                     e -> String.valueOf(e.getValue())));
                     List<LinkInfo> links = span.getLinks().stream()
                             .map(link -> new LinkInfo(
                                     link.getSpanContext().getTraceId(),
                                     link.getSpanContext().getSpanId()))
-                            .collect(Collectors.toList());
+                            .toList();
                     String statusCode = span.getStatus().getStatusCode().name();
                     String statusDescription = span.getStatus().getDescription();
                     List<EventInfo> events = span.getEvents().stream()
                             .map(event -> {
                                 Map<String, String> eventAttrs = event.getAttributes().asMap().entrySet().stream()
                                         .collect(Collectors.toMap(
-                                                e -> ((AttributeKey<?>) e.getKey()).getKey(),
+                                                e -> e.getKey().getKey(),
                                                 e -> String.valueOf(e.getValue())));
                                 return new EventInfo(event.getName(), eventAttrs);
                             })
-                            .collect(Collectors.toList());
+                            .toList();
                     return new SpanInfo(
                             span.getName(),
                             span.getKind().name(),
@@ -167,7 +166,7 @@ public class ArtemisEndpoint {
                             links,
                             events);
                 })
-                .collect(Collectors.toList());
+                .toList();
     }
 
     @DELETE

--- a/jms/runtime/src/main/java/io/quarkus/artemis/jms/runtime/health/ConnectionFactoryHealthCheck.java
+++ b/jms/runtime/src/main/java/io/quarkus/artemis/jms/runtime/health/ConnectionFactoryHealthCheck.java
@@ -36,7 +36,7 @@ public class ConnectionFactoryHealthCheck implements HealthCheck {
             @Any Instance<ConnectionFactory> connectionFactories) {
         this.runtimeConfigs = runtimeConfigs;
         this.connectionFactories = connectionFactories;
-        connectionFactoryNames = support.getConfiguredNames().stream()
+        connectionFactoryNames = support.configuredNames().stream()
                 .filter(name -> runtimeConfigs.configs().get(name).isHealthInclude())
                 .collect(Collectors.toCollection(HashSet::new));
         connectionFactoryNames.addAll(ArtemisUtil.getExternalNames(ConnectionFactory.class, runtimeConfigs, buildTimeConfigs));

--- a/jms/runtime/src/main/java/io/quarkus/artemis/jms/runtime/tracing/JmsContextPropagator.java
+++ b/jms/runtime/src/main/java/io/quarkus/artemis/jms/runtime/tracing/JmsContextPropagator.java
@@ -19,7 +19,7 @@ import io.opentelemetry.context.propagation.TextMapSetter;
  */
 class JmsContextPropagator {
 
-    private static final TextMapGetter<Message> GETTER = new TextMapGetter<Message>() {
+    private static final TextMapGetter<Message> GETTER = new TextMapGetter<>() {
         @Override
         public Iterable<String> keys(Message carrier) {
             Map<String, String> properties = new HashMap<>();
@@ -48,17 +48,14 @@ class JmsContextPropagator {
         }
     };
 
-    private static final TextMapSetter<Message> MESSAGE_SETTER = new TextMapSetter<Message>() {
-        @Override
-        public void set(Message carrier, String key, String value) {
-            if (carrier == null || key == null || value == null) {
-                return;
-            }
-            try {
-                carrier.setStringProperty(key, value);
-            } catch (JMSException e) {
-                // Ignore - best effort
-            }
+    private static final TextMapSetter<Message> MESSAGE_SETTER = (carrier, key, value) -> {
+        if (carrier == null || key == null || value == null) {
+            return;
+        }
+        try {
+            carrier.setStringProperty(key, value);
+        } catch (JMSException e) {
+            // Ignore - best effort
         }
     };
 
@@ -68,14 +65,11 @@ class JmsContextPropagator {
      * convenience send methods (String, Map, byte[], Serializable) where the Message
      * object is created internally by the JMS provider.
      */
-    private static final TextMapSetter<JMSProducer> PRODUCER_SETTER = new TextMapSetter<JMSProducer>() {
-        @Override
-        public void set(JMSProducer carrier, String key, String value) {
-            if (carrier == null || key == null || value == null) {
-                return;
-            }
-            carrier.setProperty(key, value);
+    private static final TextMapSetter<JMSProducer> PRODUCER_SETTER = (carrier, key, value) -> {
+        if (carrier == null || key == null || value == null) {
+            return;
         }
+        carrier.setProperty(key, value);
     };
 
     private final ContextPropagators propagators;

--- a/jms/runtime/src/main/java/io/quarkus/artemis/jms/runtime/tracing/TracingJMSConsumer.java
+++ b/jms/runtime/src/main/java/io/quarkus/artemis/jms/runtime/tracing/TracingJMSConsumer.java
@@ -154,19 +154,10 @@ class TracingJMSConsumer implements JMSConsumer {
     /**
      * Wrapper for MessageListener that adds tracing.
      */
-    private static class TracingMessageListener implements MessageListener {
-        private final MessageListener delegate;
-        private final Destination destination;
-        private final Tracer tracer;
-        private final JmsContextPropagator contextPropagator;
-
-        TracingMessageListener(MessageListener delegate, Destination destination, Tracer tracer,
-                JmsContextPropagator contextPropagator) {
-            this.delegate = delegate;
-            this.destination = destination;
-            this.tracer = tracer;
-            this.contextPropagator = contextPropagator;
-        }
+    private record TracingMessageListener(MessageListener delegate, Destination destination,
+            Tracer tracer, JmsContextPropagator contextPropagator)
+            implements
+                MessageListener {
 
         @Override
         public void onMessage(Message message) {
@@ -175,8 +166,7 @@ class TracingJMSConsumer implements JMSConsumer {
             // Extract context from message to create a link
             Context extractedContext = contextPropagator.extractContext(message);
 
-            SpanBuilder spanBuilder = tracer.spanBuilder(spanName)
-                    .setSpanKind(SpanKind.CONSUMER);
+            SpanBuilder spanBuilder = tracer.spanBuilder(spanName).setSpanKind(SpanKind.CONSUMER);
 
             // Use link instead of parent-child relationship
             if (extractedContext != null) {

--- a/jms/runtime/src/main/java/io/quarkus/artemis/jms/runtime/tracing/TracingMessageConsumer.java
+++ b/jms/runtime/src/main/java/io/quarkus/artemis/jms/runtime/tracing/TracingMessageConsumer.java
@@ -34,7 +34,7 @@ class TracingMessageConsumer implements MessageConsumer {
 
     @Override
     public Message receive() throws JMSException {
-        return receiveWithTracing(() -> delegate.receive());
+        return receiveWithTracing(delegate::receive);
     }
 
     @Override
@@ -44,7 +44,7 @@ class TracingMessageConsumer implements MessageConsumer {
 
     @Override
     public Message receiveNoWait() throws JMSException {
-        return receiveWithTracing(() -> delegate.receiveNoWait());
+        return receiveWithTracing(delegate::receiveNoWait);
     }
 
     private Message receiveWithTracing(JmsReceiveOperation operation) throws JMSException {
@@ -119,19 +119,10 @@ class TracingMessageConsumer implements MessageConsumer {
     /**
      * Wrapper for MessageListener that adds tracing to onMessage calls.
      */
-    private static class TracingMessageListener implements MessageListener {
-        private final MessageListener delegate;
-        private final Destination destination;
-        private final Tracer tracer;
-        private final JmsContextPropagator contextPropagator;
-
-        TracingMessageListener(MessageListener delegate, Destination destination, Tracer tracer,
-                JmsContextPropagator contextPropagator) {
-            this.delegate = delegate;
-            this.destination = destination;
-            this.tracer = tracer;
-            this.contextPropagator = contextPropagator;
-        }
+    private record TracingMessageListener(MessageListener delegate, Destination destination,
+            Tracer tracer, JmsContextPropagator contextPropagator)
+            implements
+                MessageListener {
 
         @Override
         public void onMessage(Message message) {
@@ -140,8 +131,7 @@ class TracingMessageConsumer implements MessageConsumer {
             // Extract context from message to create a link
             Context extractedContext = contextPropagator.extractContext(message);
 
-            SpanBuilder spanBuilder = tracer.spanBuilder(spanName)
-                    .setSpanKind(SpanKind.CONSUMER);
+            SpanBuilder spanBuilder = tracer.spanBuilder(spanName).setSpanKind(SpanKind.CONSUMER);
 
             // Use link instead of parent-child relationship
             if (extractedContext != null) {


### PR DESCRIPTION
- use records where applicable
- remove unnecessary casts
- in streams, use ".toList()" instead of ".collect(Collectors.toList())"
- Remove explicit type parameters where the type can be inferred
- use lambdas instead of anonymous interface implementations where possible
- Use method references instead of lambdas where applicable