### PR TITLE
Switch artemis broker image

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/artemis/core/runtime/ArtemisDevServicesBuildTimeConfig.java
+++ b/core/runtime/src/main/java/io/quarkus/artemis/core/runtime/ArtemisDevServicesBuildTimeConfig.java
@@ -7,7 +7,7 @@ import io.quarkus.runtime.annotations.ConfigGroup;
 @ConfigGroup
 public interface ArtemisDevServicesBuildTimeConfig {
 
-    String DEFAULT_IMAGE = "quay.io/arkmq-org/activemq-artemis-broker:artemis.2.53.0";
+    String DEFAULT_IMAGE = "quay.io/arkmq-org/arkmq-org-broker:artemis.2.55.0";
 
     /**
      * Enable or disable Dev Services explicitly. Dev Services are automatically enabled unless
@@ -32,7 +32,7 @@ public interface ArtemisDevServicesBuildTimeConfig {
     /**
      * The ActiveMQ Artemis container image to use.
      * <p>
-     * Defaults to {@code quay.io/arkmq-org/activemq-artemis-broker:artemis.2.53.0}
+     * Defaults to {@code quay.io/arkmq-org/arkmq-org-broker:artemis.2.55.0}
      */
     Optional<String> imageName();
 

--- a/ra/runtime/src/main/java/io/quarkus/artemis/jms/ra/runtime/ArtemisDevServicesBuildTimeConfig.java
+++ b/ra/runtime/src/main/java/io/quarkus/artemis/jms/ra/runtime/ArtemisDevServicesBuildTimeConfig.java
@@ -39,7 +39,7 @@ public interface ArtemisDevServicesBuildTimeConfig {
     /**
      * The ActiveMQ Artemis container image to use.
      * <p>
-     * Defaults to {@code quay.io/arkmq-org/activemq-artemis-broker:artemis.2.53.0}
+     * Defaults to {@code quay.io/arkmq-org/arkmq-org-broker:artemis.2.55.0}
      */
     Optional<String> imageName();
 


### PR DESCRIPTION
It seems that the image we use moved from quay.io/arkmq-org/activemq-artemis-broker to quay.io/arkmq-org/arkmq-org-broker